### PR TITLE
feat(section3): 新增 Hooks & SDK 互動式教學筆記

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sw.*
 .output
 backup
 settings.local.json
+content/8.2026-plan/section3/downloads/

--- a/components/AppSubtitle.vue
+++ b/components/AppSubtitle.vue
@@ -12,11 +12,15 @@ const contributors = reactive<string[]>([]);
 const title = ref("");
 
 onMounted(() => {
-  title.value = page.value && page.value.pageTitle ? page.value.pageTitle : "";
+  if (!page.value) return;
+
+  title.value = page.value.pageTitle ? page.value.pageTitle : "";
 
   if (Array.isArray(page.value.contributors)) {
     contributors.push(...page.value.contributors);
   }
+
+  if (!page.value.body) return;
 
   const contentArray = Array.isArray(page.value.body.children)
     ? page.value.body.children
@@ -58,9 +62,9 @@ onMounted(() => {
         閱讀時長：{{ Math.ceil(readTime.minutes) }} 分鐘
       </span>
       <span class="mx-1">|</span>
-      <span class="text-xs md:text-sm" id="busuanzi_container_page_pv">
+      <span id="busuanzi_container_page_pv" class="text-xs md:text-sm">
         <span>閱讀次數：</span>
-        <span id="busuanzi_value_page_pv"></span>
+        <span id="busuanzi_value_page_pv" />
         次
       </span>
     </div>

--- a/content/8.2026-plan/section3/1.overview.md
+++ b/content/8.2026-plan/section3/1.overview.md
@@ -1,0 +1,27 @@
+---
+title: "總覽"
+pageTitle: "Part 3 - Section 1: Hooks & SDK"
+contributors: ["yulin0629"]
+---
+
+## 課程資訊
+
+- **課程**：[Anthropic Courses — Claude Code in Action](https://anthropic.skilljar.com/claude-code-in-action)
+- **章節**：Part 3 · Section 1 — Hooks & SDK
+- 📢 **分享者**：王以謙 ｜ **GitHub**：[yulin0629](https://github.com/yulin0629)
+
+## 學習目標
+
+> 理解 Hooks 機制並實作自訂 hook，識別常見陷阱與注意事項，透過 Claude Code SDK 將 AI 能力整合進自有工具鏈與自動化流程
+
+## 對應 Lessons
+
+| Lesson | 主題 | 對應筆記 |
+|---|---|---|
+| 312000 | Introducing hooks | TBD |
+| 312002 | Defining hooks | TBD |
+| 312003 | Implementing a hook | TBD |
+| 312004 | Useful hooks | TBD |
+| 312423 | Gotchas around hooks | TBD |
+| 312427 | Another useful hook | TBD |
+| 312001 | The Claude Code SDK | TBD |

--- a/content/8.2026-plan/section3/1.overview.md
+++ b/content/8.2026-plan/section3/1.overview.md
@@ -14,14 +14,66 @@ contributors: ["yulin0629"]
 
 > 理解 Hooks 機制並實作自訂 hook，識別常見陷阱與注意事項，透過 Claude Code SDK 將 AI 能力整合進自有工具鏈與自動化流程
 
-## 對應 Lessons
+## 本章涵蓋主題與分享範圍
 
-| Lesson | 主題 |
-|---|---|
-| 312000 | <a href="/2026-plan/section3/312000-introducing-hooks.html" target="_blank">Introducing hooks</a> |
-| 312002 | <a href="/2026-plan/section3/312002-defining-hooks.html" target="_blank">Defining hooks</a> |
-| 312003 | <a href="/2026-plan/section3/312003-implementing-a-hook.html" target="_blank">Implementing a hook</a> |
-| 312004 | <a href="/2026-plan/section3/312004-useful-hooks.html" target="_blank">Useful hooks</a> |
-| 312423 | <a href="/2026-plan/section3/312423-gotchas-around-hooks.html" target="_blank">Gotchas around hooks</a> |
-| 312427 | <a href="/2026-plan/section3/312427-another-useful-hook.html" target="_blank">Another useful hook</a> |
-| 312001 | <a href="/2026-plan/section3/312001-the-claude-code-sdk.html" target="_blank">The Claude Code SDK</a> |
+| Lesson | 主題 | 本次分享 |
+|---|---|---|
+| 312000 | <a href="/2026-plan/section3/312000-introducing-hooks.html" target="_blank">Introducing hooks</a> | ✅ |
+| 312002 | <a href="/2026-plan/section3/312002-defining-hooks.html" target="_blank">Defining hooks</a> | ✅ |
+| 312003 | <a href="/2026-plan/section3/312003-implementing-a-hook.html" target="_blank">Implementing a hook</a> | ✅ |
+| 312004 | <a href="/2026-plan/section3/312004-useful-hooks.html" target="_blank">Useful hooks</a> | ✅ |
+| 312423 | <a href="/2026-plan/section3/312423-gotchas-around-hooks.html" target="_blank">Gotchas around hooks</a> | ✅ |
+| 312427 | <a href="/2026-plan/section3/312427-another-useful-hook.html" target="_blank">Another useful hook</a> | ✅ |
+| 312001 | <a href="/2026-plan/section3/312001-the-claude-code-sdk.html" target="_blank">The Claude Code SDK</a> | ✅ |
+
+## 各 Lesson 速覽
+
+### 1. Introducing hooks
+
+Hooks 是 Claude Code 的攔截機制，可在工具呼叫前（PreToolUse）或後（PostToolUse）執行自訂命令，實現程式碼格式化、測試、存取控制等自動化流程。
+
+→ <a href="/2026-plan/section3/312000-introducing-hooks.html" target="_blank">前往閱讀</a>
+
+### 2. Defining hooks
+
+定義 Hook 的四個步驟：選擇 PreToolUse 或 PostToolUse、指定監聽的工具、撰寫接收 JSON stdin 的命令、透過 exit code 控制行為（0 放行、2 阻擋）。
+
+→ <a href="/2026-plan/section3/312002-defining-hooks.html" target="_blank">前往閱讀</a>
+
+### 3. Implementing a hook
+
+實作一個 PreToolUse hook，阻止 Claude 讀取 `.env` 檔案。從建立 Node.js 腳本、解析 stdin JSON、檢查檔案路徑到以 exit code 2 阻擋敏感操作的完整流程。
+
+→ <a href="/2026-plan/section3/312003-implementing-a-hook.html" target="_blank">前往閱讀</a>
+
+### 4. Useful hooks
+
+兩個實用的生產級 Hook：TypeScript 型別檢查 hook（編輯後自動執行 `tsc` 捕捉簽名不匹配），以及查詢重複偵測 hook（使用 Agent SDK 啟動獨立 Claude 實例檢查資料庫查詢是否重複）。
+
+→ <a href="/2026-plan/section3/312004-useful-hooks.html" target="_blank">前往閱讀</a>
+
+### 5. Gotchas around hooks
+
+Hook 腳本應使用絕對路徑以防止路徑攔截攻擊，但這會讓設定難以在團隊間共享。解法是在 `settings.example.json` 中使用 `$PWD` 佔位符，搭配 `init-claude.js` 腳本在設定時自動替換為實際專案路徑。
+
+→ <a href="/2026-plan/section3/312423-gotchas-around-hooks.html" target="_blank">前往閱讀</a>
+
+### 6. Another useful hook
+
+除了 PreToolUse 和 PostToolUse，Claude Code 還支援 Notification、Stop、SubagentStop、PreCompact、UserPromptSubmit 等 Hook 類型。建議先用 `jq` debug hook 檢查各 hook 的 stdin 結構，再實作正式邏輯。
+
+→ <a href="/2026-plan/section3/312427-another-useful-hook.html" target="_blank">前往閱讀</a>
+
+### 7. The Claude Code SDK
+
+Agent SDK 讓你從 TypeScript 或 Python 程式化驅動 Claude Code，提供與 CLI 相同的完整能力（檔案讀寫、工具呼叫），支援自訂 prompt、MCP servers、hooks、subagents 與工具白名單。
+
+→ <a href="/2026-plan/section3/312001-the-claude-code-sdk.html" target="_blank">前往閱讀</a>
+
+## 建議閱讀順序
+
+1. **先讀 Introducing hooks** — 建立 Hook 機制的整體概念
+2. **接著 Defining hooks → Implementing a hook** — 從定義到實作的完整流程
+3. **再讀 Useful hooks + Another useful hook** — 了解進階應用場景與更多 Hook 類型
+4. **注意 Gotchas around hooks** — 掌握安全性與團隊協作的注意事項
+5. **最後讀 The Claude Code SDK** — 將 Claude Code 能力整合進自有工具鏈

--- a/content/8.2026-plan/section3/1.overview.md
+++ b/content/8.2026-plan/section3/1.overview.md
@@ -16,12 +16,12 @@ contributors: ["yulin0629"]
 
 ## 對應 Lessons
 
-| Lesson | 主題 | 對應筆記 |
-|---|---|---|
-| 312000 | Introducing hooks | TBD |
-| 312002 | Defining hooks | TBD |
-| 312003 | Implementing a hook | TBD |
-| 312004 | Useful hooks | TBD |
-| 312423 | Gotchas around hooks | TBD |
-| 312427 | Another useful hook | TBD |
-| 312001 | The Claude Code SDK | TBD |
+| Lesson | 主題 |
+|---|---|
+| 312000 | <a href="/2026-plan/section3/312000-introducing-hooks.html" target="_blank">Introducing hooks</a> |
+| 312002 | <a href="/2026-plan/section3/312002-defining-hooks.html" target="_blank">Defining hooks</a> |
+| 312003 | <a href="/2026-plan/section3/312003-implementing-a-hook.html" target="_blank">Implementing a hook</a> |
+| 312004 | <a href="/2026-plan/section3/312004-useful-hooks.html" target="_blank">Useful hooks</a> |
+| 312423 | <a href="/2026-plan/section3/312423-gotchas-around-hooks.html" target="_blank">Gotchas around hooks</a> |
+| 312427 | <a href="/2026-plan/section3/312427-another-useful-hook.html" target="_blank">Another useful hook</a> |
+| 312001 | <a href="/2026-plan/section3/312001-the-claude-code-sdk.html" target="_blank">The Claude Code SDK</a> |

--- a/content/8.2026-plan/section3/AGENTS.md
+++ b/content/8.2026-plan/section3/AGENTS.md
@@ -41,9 +41,10 @@
 
 - 遵守專案根目錄 `AGENT.md` 的 Conventional Commits 規範（header ≤ 150 字、body line ≤ 200 字）。
 - scope 建議使用 `8.2026-plan` 或 `section3`。
+- emoji 必須放在 `type(scope):` **之後**，不能放開頭（commitlint 會 fail）。
 - 範例：
-  - `✨ feat(section3): add introducing-hooks note`
-  - `📝 docs(section3): refine overview learning objectives`
+  - `feat(section3): ✨ add introducing-hooks note`
+  - `docs(section3): 📝 refine overview learning objectives`
 
 ## 不要做的事
 

--- a/content/8.2026-plan/section3/AGENTS.md
+++ b/content/8.2026-plan/section3/AGENTS.md
@@ -1,0 +1,53 @@
+# Section 3 — Hooks & SDK 工作守則
+
+本目錄是 **2026 讀書計畫 Part 3 · Section 1: Hooks & SDK** 的筆記區。
+分享者 / 維護者：王以謙（GitHub: [yulin0629](https://github.com/yulin0629)）。
+
+## 來源素材
+
+- 課程：[Anthropic Courses — Claude Code in Action](https://anthropic.skilljar.com/claude-code-in-action)
+- 章節：Part 3 · Section 1 — Hooks & SDK
+- 原始素材位於 `./downloads/anthropic-claude-code-in-action-hooks-and-sdk/pages/`
+- `downloads/` 目錄已被 `.gitignore` 排除（內含 mp4 / srt / jpg），**不要 commit**
+
+涵蓋 7 個 lesson（皆有對應的 `.md` 在 downloads 內）：
+
+| Lesson ID | 主題 |
+|---|---|
+| 312000 | Introducing hooks |
+| 312002 | Defining hooks |
+| 312003 | Implementing a hook |
+| 312004 | Useful hooks |
+| 312423 | Gotchas around hooks |
+| 312427 | Another useful hook |
+| 312001 | The Claude Code SDK |
+
+## 寫作原則
+
+1. **以 downloads 內的 markdown 為事實來源** — 任何摘要、條列、引用都要能對得回原文。不要憑印象或目錄名稱推測內容。
+2. **不要編造學習目標、章節介紹或 lesson 摘要** — 若要寫，請先 Read 原文後再下筆；不確定就留空（`_____`）或 `TBD`。
+3. **格式與 section1 / section2 一致** — 參考 `../section1/1.overview.md`、`../section2/1.overview.md` 的 frontmatter 與段落結構。
+4. **檔案命名沿用既有規則** — 數字前綴控制排序（`1.overview.md`、`2.xxx.md`…），檔名用 kebab-case。
+5. **頁面 frontmatter** 至少含 `title`、`pageTitle`、`contributors`。
+
+## 圖片處理
+
+- 真正寫進筆記的圖片，**從 `downloads/.../images/` 複製到 `public/images/8.2026-plan/section3/<lesson-slug>/`**。
+- Markdown 內以 `images/8.2026-plan/section3/<lesson-slug>/xxx.png` 形式引用（不要寫絕對路徑或前綴 `/`）。
+- `server/plugins/content.ts` 會在 build time 為 `images/` 開頭的路徑自動補上 `BASE_URL`，因此本地與 GitHub Pages 都會解析正確。
+- 不要直接從 `downloads/` 引用圖片 — 那個目錄不會被 deploy。
+
+## Commit 規範
+
+- 遵守專案根目錄 `AGENT.md` 的 Conventional Commits 規範（header ≤ 150 字、body line ≤ 200 字）。
+- scope 建議使用 `8.2026-plan` 或 `section3`。
+- 範例：
+  - `✨ feat(section3): add introducing-hooks note`
+  - `📝 docs(section3): refine overview learning objectives`
+
+## 不要做的事
+
+- **不要修改 `downloads/`** — 那是課程原始素材的本地快照。
+- **不要把 mp4 / srt / 大圖一起 commit** — 確認 `.gitignore` 仍排除 `content/8.2026-plan/section3/downloads/`。
+- **不要替使用者填上「分享者」、「contributors」以外的個資**。
+- **不要跨 section 改動** — 此 AGENTS.md 範圍僅限 `section3/`。

--- a/content/8.2026-plan/section3/CLAUDE.md
+++ b/content/8.2026-plan/section3/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/content/8.2026-plan/section3/_dir.yml
+++ b/content/8.2026-plan/section3/_dir.yml
@@ -1,0 +1,2 @@
+title: 'Section 3 - Hooks & SDK'
+icon: 🪝

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -30,6 +30,7 @@ export default defineNuxtConfig({
     },
   },
   content: {
+    ignores: ['AGENTS\\.md$', 'CLAUDE\\.md$'],
     navigation: {
       fields: ['icon', 'titleTemplate', 'header', 'main', 'aside', 'footer', 'group']
     },

--- a/public/2026-plan/section3/312000-introducing-hooks.html
+++ b/public/2026-plan/section3/312000-introducing-hooks.html
@@ -1,0 +1,538 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code Hooks 沉浸式教學指南</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&family=JetBrains+Mono:wght@400;700&display=swap');
+
+        body {
+            font-family: 'Noto Sans TC', sans-serif;
+            background-color: #F4F4F0;
+            color: #2D2D2D;
+            line-height: 1.6;
+        }
+        .font-mono {
+            font-family: 'JetBrains Mono', monospace;
+        }
+        
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+        .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+
+        /* 終端機打字游標動畫 */
+        .cursor-blink {
+            animation: blink 1s step-end infinite;
+        }
+        @keyframes blink {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0; }
+        }
+
+        /* 淡入動畫 */
+        .fade-in {
+            animation: fadeIn 0.4s ease-out forwards;
+            opacity: 0;
+            transform: translateY(10px);
+        }
+        @keyframes fadeIn {
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        /* 漸層文字與卡片 */
+        .glass-panel {
+            background: rgba(255, 255, 255, 0.7);
+            backdrop-filter: blur(10px);
+            border: 1px solid rgba(255, 255, 255, 0.5);
+        }
+
+        /* 檔案樹選取狀態 */
+        .file-active {
+            background-color: #E5E7EB;
+            border-left: 4px solid #D97742;
+            font-weight: 700;
+        }
+        .file-inactive {
+            border-left: 4px solid transparent;
+        }
+        .file-inactive:hover {
+            background-color: #F3F4F6;
+        }
+    </style>
+</head>
+<body class="antialiased pb-24">
+
+    <!-- Header -->
+    <header class="bg-[#111111] text-white py-20 px-6 shadow-2xl relative overflow-hidden border-b-[6px] border-[#D97742]">
+        <div class="absolute inset-0 opacity-20 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGNpcmNsZSBjeD0iMSIgY3k9IjEiIHI9IjEiIGZpbGw9IiNmZmYiLz48L3N2Zz4=')]"></div>
+        <div class="max-w-5xl mx-auto relative z-10">
+            <span class="inline-block px-3 py-1 bg-white/10 text-gray-300 text-sm font-mono rounded-full mb-6 border border-white/20">
+                > learning_module --topic="Hooks"
+            </span>
+            <h1 class="text-4xl md:text-6xl font-bold mb-6 tracking-tight">掌控 Claude 的行動：<br><span class="text-transparent bg-clip-text bg-gradient-to-r from-[#FFB085] to-[#D97742]">Hooks 攔截與自動化機制</span></h1>
+            <p class="text-lg md:text-xl text-gray-400 max-w-2xl leading-relaxed">
+                你不必總是讓 AI 自主決定一切。透過設定 Hooks，你可以在 Claude 執行工具的「事前 (Pre)」強制踩煞車，或在「事後 (Post)」觸發程式碼檢查並回傳修正建議。
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-6 mt-16 space-y-20">
+
+        <!-- 模組 1：終端機模擬器 (情境體驗) -->
+        <section>
+            <div class="mb-8">
+                <h2 class="text-3xl font-bold text-gray-900 flex items-center">
+                    <svg class="w-8 h-8 mr-3 text-[#D97742]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                    1. 為什麼需要 Hooks？(實境模擬)
+                </h2>
+                <p class="text-gray-600 mt-2 text-lg">與其用文字解釋，不如直接看看沒有 Hook 和有 Hook 時，Claude Code 在終端機裡的真實反應。</p>
+            </div>
+
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+                <!-- 模擬器控制面板 -->
+                <div class="glass-panel p-8 rounded-2xl shadow-sm flex flex-col justify-center">
+                    <h3 class="text-xl font-bold mb-4">情境：Claude 試圖讀取機密檔案 <code>.env</code></h3>
+                    <p class="text-gray-600 mb-8">專案中的 <code>.env</code> 包含了資料庫密碼與 API Key。身為工程師，你希望絕對禁止 AI 讀取它。</p>
+                    
+                    <div class="space-y-4">
+                        <button onclick="runTerminal('no-hook')" class="w-full text-left px-6 py-4 rounded-xl border-2 border-gray-300 hover:border-gray-500 hover:bg-gray-50 transition-all font-bold text-gray-700 flex justify-between items-center group">
+                            <span>▶ 模擬：無防護狀態 (No Hooks)</span>
+                            <span class="text-gray-400 group-hover:text-gray-600">➔</span>
+                        </button>
+                        <button onclick="runTerminal('pre-hook')" class="w-full text-left px-6 py-4 rounded-xl border-2 border-[#D97742] bg-[#FFF5F0] hover:bg-[#FFEAE0] transition-all font-bold text-[#A64E1B] flex justify-between items-center group shadow-md">
+                            <span>▶ 模擬：啟用 PreToolUse 攔截</span>
+                            <span class="text-[#D97742] group-hover:text-[#A64E1B]">➔</span>
+                        </button>
+                    </div>
+                </div>
+
+                <!-- 終端機 UI -->
+                <div class="bg-[#1E1E1E] rounded-2xl shadow-2xl overflow-hidden border border-gray-700 flex flex-col h-[400px]">
+                    <div class="bg-[#2D2D2D] px-4 py-3 flex items-center gap-2 shrink-0">
+                        <div class="w-3 h-3 rounded-full bg-[#FF5F56]"></div>
+                        <div class="w-3 h-3 rounded-full bg-[#FFBD2E]"></div>
+                        <div class="w-3 h-3 rounded-full bg-[#27C93F]"></div>
+                        <span class="ml-4 text-xs text-gray-400 font-mono">claude-code-terminal</span>
+                    </div>
+                    <div id="terminal-content" class="p-5 font-mono text-sm leading-relaxed overflow-y-auto flex-grow text-gray-300 no-scrollbar">
+                        <div class="text-gray-500 mb-4"># 點擊左側按鈕開始模擬...</div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 模組 2：運作機制 (互動時序圖回歸) -->
+        <section>
+            <div class="mb-8 flex flex-col md:flex-row justify-between items-start md:items-end gap-4">
+                <div>
+                    <h2 class="text-3xl font-bold text-gray-900 flex items-center">
+                        <svg class="w-8 h-8 mr-3 text-[#D97742]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>
+                        2. 完整運作機制與介入時機
+                    </h2>
+                    <p class="text-gray-600 mt-2 text-lg">除了單純的阻擋，透過點擊「下一步」來演練 Claude 呼叫工具的完整生命週期與回饋迴圈。</p>
+                </div>
+                <div class="flex gap-3 shrink-0">
+                    <button onclick="resetFlow()" class="px-5 py-2.5 text-sm font-medium text-gray-600 bg-white hover:bg-gray-100 border border-gray-300 rounded-lg transition-colors shadow-sm">重置流程</button>
+                    <button id="nextBtn" onclick="nextFlowStep()" class="px-5 py-2.5 text-sm font-bold text-white bg-[#111] hover:bg-gray-800 rounded-lg transition-colors shadow-md flex items-center">
+                        下一步 <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+                    </button>
+                </div>
+            </div>
+
+            <div class="bg-white rounded-2xl shadow-lg border border-gray-200 p-4 md:p-8">
+                <!-- 動態畫布區：外層加入 overflow-x-auto，確保手機版可以橫向捲動 -->
+                <div class="w-full overflow-x-auto no-scrollbar shadow-inner border border-gray-200 rounded-xl bg-[#F9F9F7]">
+                    <!-- 內部畫布：強制最小寬度 800px，防止擠壓 -->
+                    <div class="relative min-w-[800px] p-6 min-h-[500px]">
+                        <!-- 參與者 Header -->
+                        <div class="flex justify-between relative z-10 mb-10">
+                            <div class="w-1/3 text-center"><span class="bg-white border-2 border-gray-300 rounded-lg px-6 py-3 font-bold shadow-sm text-gray-800">使用者 (You)</span></div>
+                            <div class="w-1/3 text-center"><span class="bg-white border-2 border-[#D97742] rounded-lg px-6 py-3 font-bold shadow-sm text-[#D97742]">本機端 Claude Code</span></div>
+                            <div class="w-1/3 text-center"><span class="bg-[#111] border-2 border-[#111] rounded-lg px-6 py-3 font-bold shadow-sm text-white flex items-center justify-center mx-auto w-fit">
+                                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"></path></svg>
+                                Claude 雲端模型
+                            </span></div>
+                        </div>
+
+                        <!-- 垂直軌道線 (相對於 800px 畫布絕對定位) -->
+                        <div class="absolute top-16 bottom-0 left-[16.66%] w-px border-l-2 border-dashed border-gray-300"></div>
+                        <div class="absolute top-16 bottom-0 left-[50%] w-px border-l-2 border-dashed border-[#D97742] opacity-50"></div>
+                        <div class="absolute top-16 bottom-0 left-[83.33%] w-px border-l-2 border-dashed border-gray-300"></div>
+
+                        <!-- 步驟容器 -->
+                        <div id="flowContainer" class="relative space-y-10 mt-12 z-20">
+                            <!-- JS 動態注入步驟 -->
+                        </div>
+                    </div>
+                </div>
+                
+                <!-- 教學提詞機 -->
+                <div class="mt-6 p-4 md:p-5 bg-blue-50 border-l-4 border-blue-500 rounded-r-lg shadow-sm transition-opacity duration-300" id="flowExplanationBox">
+                    <h4 class="font-bold text-blue-900 mb-1 flex items-center text-sm md:text-base">
+                        <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                        教學重點說明
+                    </h4>
+                    <div id="flowExplanation" class="text-blue-800 md:text-lg">
+                        請點擊右上角的「下一步」開始演練流程。如果是手機版，請左右滑動上方圖表觀看。
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 模組 3：設定檔在哪裡？(互動檔案樹) -->
+        <section>
+            <div class="mb-8">
+                <h2 class="text-3xl font-bold text-gray-900 flex items-center">
+                    <svg class="w-8 h-8 mr-3 text-[#D97742]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                    3. Hook 的註冊位置 (設定檔層級)
+                </h2>
+                <p class="text-gray-600 mt-2 text-lg">除了在對話框輸入 <code>/hooks</code> 指令，你也可以手動編輯設定檔。Claude 支援三種層級的配置檔。</p>
+            </div>
+
+            <div class="flex flex-col lg:flex-row gap-6 bg-white rounded-2xl shadow-sm border border-gray-200 overflow-hidden">
+                <!-- 檔案樹 (左側) -->
+                <div class="lg:w-1/3 bg-[#F9FAFB] border-r border-gray-200 p-4">
+                    <div class="text-xs font-bold text-gray-400 mb-4 uppercase tracking-wider pl-2">設定檔目錄 (Config Files)</div>
+                    <ul class="space-y-1 font-mono text-sm">
+                        <li id="file-global" onclick="selectFile('global')" class="file-active p-3 rounded-lg cursor-pointer flex items-center transition-colors">
+                            <svg class="w-5 h-5 mr-3 text-blue-500" fill="currentColor" viewBox="0 0 24 24"><path d="M3 5a2 2 0 012-2h4l2 2h10a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V5z"></path></svg>
+                            ~/.claude/settings.json
+                        </li>
+                        <li id="file-project" onclick="selectFile('project')" class="file-inactive p-3 rounded-lg cursor-pointer flex items-center transition-colors text-gray-600">
+                            <svg class="w-5 h-5 mr-3 text-yellow-500" fill="currentColor" viewBox="0 0 24 24"><path d="M3 5a2 2 0 012-2h4l2 2h10a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V5z"></path></svg>
+                            .claude/settings.json
+                        </li>
+                        <li id="file-local" onclick="selectFile('local')" class="file-inactive p-3 rounded-lg cursor-pointer flex items-center transition-colors text-gray-600">
+                            <svg class="w-5 h-5 mr-3 text-gray-400" fill="currentColor" viewBox="0 0 24 24"><path d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8V7z"></path></svg>
+                            .claude/settings.local.json
+                        </li>
+                    </ul>
+                </div>
+                
+                <!-- 檔案說明與內容 (右側) -->
+                <div class="lg:w-2/3 p-8 flex flex-col justify-center min-h-[300px]">
+                    <div id="file-content-global">
+                        <span class="bg-blue-100 text-blue-800 text-xs font-bold px-3 py-1 rounded-full border border-blue-200">Global (全域)</span>
+                        <h3 class="text-2xl font-bold mt-4 mb-2">影響你電腦上的所有專案</h3>
+                        <p class="text-gray-600 mb-4">放在 User 的 Home 目錄下。適合設定你個人的防護習慣，例如：「永遠禁止讀取任何名為 .env 的檔案」。這對你機器上執行的所有 Claude Code 專案都有效。</p>
+                    </div>
+                    <div id="file-content-project" class="hidden">
+                        <span class="bg-yellow-100 text-yellow-800 text-xs font-bold px-3 py-1 rounded-full border border-yellow-200">Project (專案共用)</span>
+                        <h3 class="text-2xl font-bold mt-4 mb-2">團隊共享的規範</h3>
+                        <p class="text-gray-600 mb-4">放在專案資料夾內，<strong>應該被 Commit 到 Git 中</strong>。適合設定團隊共同的規範，例如：「只要編輯過 JS 檔，就統一執行專案裡的 <code>npm run format</code>」。這樣團隊中任何使用 Claude Code 的人，都會遵守這個規範。</p>
+                    </div>
+                    <div id="file-content-local" class="hidden">
+                        <span class="bg-gray-100 text-gray-800 text-xs font-bold px-3 py-1 rounded-full border border-gray-300">Local (本機不提交)</span>
+                        <h3 class="text-2xl font-bold mt-4 mb-2">專屬你的個人覆寫</h3>
+                        <p class="text-gray-600 mb-4">放在專案資料夾內，但<strong>必須加入 <code>.gitignore</code> 中不提交</strong>。適合你在本地端開發時，想加上一些只對你個人有用的 Hook 測試或暫時性的除錯指令。</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 模組 4：動態 JSON 建構器 -->
+        <section>
+            <div class="mb-8 border-b-2 border-gray-200 pb-4">
+                <h2 class="text-3xl font-bold text-gray-900 flex items-center">
+                    <svg class="w-8 h-8 mr-3 text-[#D97742]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path></svg>
+                    4. 實戰：編寫 Hook 規則
+                </h2>
+                <p class="text-gray-600 mt-2 text-lg">除了在命令列輸入 <code>/hooks</code>，了解 JSON 結構能讓你寫出更強大的正則攔截條件。</p>
+            </div>
+
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+                <!-- 設定面板 -->
+                <div class="space-y-6 bg-white p-6 rounded-2xl shadow-sm border border-gray-200">
+                    <div>
+                        <label class="block text-sm font-bold text-gray-800 mb-2">觸發階段 (Hook Type)</label>
+                        <select id="config-type" class="w-full p-3 border border-gray-300 rounded-lg bg-[#F9F9F7] focus:ring-2 focus:ring-[#D97742] outline-none" onchange="generateJson()">
+                            <option value="PreToolUse">PreToolUse (事前阻擋)</option>
+                            <option value="PostToolUse">PostToolUse (事後加工/回饋)</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-bold text-gray-800 mb-1">目標工具 (Matcher Regex)</label>
+                        <p class="text-xs text-gray-500 mb-2">支援正則表達式，例如攔截所有寫入操作：Write|Edit|MultiEdit</p>
+                        <input type="text" id="config-matcher" value="Read" class="w-full p-3 border border-gray-300 rounded-lg bg-[#F9F9F7] font-mono text-sm focus:ring-2 focus:ring-[#D97742] outline-none" oninput="generateJson()">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-bold text-gray-800 mb-1">執行指令 (Command)</label>
+                        <input type="text" id="config-command" value="node check_auth.js" class="w-full p-3 border border-gray-300 rounded-lg bg-[#F9F9F7] font-mono text-sm text-blue-700 focus:ring-2 focus:ring-[#D97742] outline-none" oninput="generateJson()">
+                    </div>
+                    <div class="pt-4 border-t border-gray-200">
+                        <span class="text-sm font-bold text-gray-700 block mb-3">一鍵載入實務範例：</span>
+                        <div class="flex flex-col gap-2">
+                            <button onclick="applyPreset('block')" class="text-left px-3 py-2 bg-red-50 text-red-700 border border-red-200 rounded-lg hover:bg-red-100 transition-colors text-sm font-medium">
+                                🛑 事前阻擋讀取特定檔案
+                            </button>
+                            <button onclick="applyPreset('format')" class="text-left px-3 py-2 bg-blue-50 text-blue-700 border border-blue-200 rounded-lg hover:bg-blue-100 transition-colors text-sm font-medium">
+                                📝 編輯後自動執行 Formatter
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- 程式碼輸出 -->
+                <div class="bg-[#1E1E1E] rounded-2xl shadow-xl flex flex-col w-full overflow-hidden border border-gray-700">
+                    <div class="bg-[#2D2D2D] px-4 py-3 flex items-center gap-2 border-b border-gray-700 shrink-0">
+                        <div class="w-3 h-3 rounded-full bg-[#FF5F56]"></div>
+                        <div class="w-3 h-3 rounded-full bg-[#FFBD2E]"></div>
+                        <div class="w-3 h-3 rounded-full bg-[#27C93F]"></div>
+                        <span class="ml-4 text-sm text-gray-300 font-mono">settings.json</span>
+                    </div>
+                    <div class="w-full overflow-x-auto no-scrollbar p-6">
+                        <pre class="text-sm text-[#D4D4D4] font-mono leading-relaxed"><code id="json-output"></code></pre>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <footer class="text-center text-gray-500 text-sm mt-20 py-10 border-t border-gray-200 bg-white">
+        <p>這是一份沉浸式互動教學教材，旨在透過模擬與圖解，徹底釐清 Claude Code Hooks 架構。</p>
+    </footer>
+
+    <script>
+        // --- 模組 1: 終端機模擬器 ---
+        const terminalOutput = document.getElementById('terminal-content');
+        let isSimulating = false;
+
+        async function typeText(text, colorClass = "text-gray-300", delayMs = 30) {
+            const line = document.createElement('div');
+            line.className = `${colorClass} mb-1`;
+            terminalOutput.appendChild(line);
+            
+            for (let i = 0; i < text.length; i++) {
+                line.innerHTML += text.charAt(i);
+                terminalOutput.scrollTop = terminalOutput.scrollHeight;
+                await new Promise(r => setTimeout(r, delayMs));
+            }
+        }
+
+        async function insertStaticLine(text, colorClass = "text-gray-300") {
+            const line = document.createElement('div');
+            line.className = `${colorClass} mb-1`;
+            line.innerHTML = text;
+            terminalOutput.appendChild(line);
+            terminalOutput.scrollTop = terminalOutput.scrollHeight;
+        }
+
+        async function runTerminal(mode) {
+            if (isSimulating) return;
+            isSimulating = true;
+            terminalOutput.innerHTML = ''; // Clear
+
+            await typeText("> claude \"請讀取 .env 檔案並告訴我資料庫密碼\"", "text-green-400 font-bold");
+            await new Promise(r => setTimeout(r, 600));
+            
+            await insertStaticLine("🤖 Claude 正在思考...", "text-blue-400 italic");
+            await new Promise(r => setTimeout(r, 800));
+            
+            await insertStaticLine("⚙️ Claude 決定調用工具: <span class='text-purple-400'>ReadFile('.env')</span>");
+            await new Promise(r => setTimeout(r, 800));
+
+            if (mode === 'no-hook') {
+                await insertStaticLine("🔓 [警告] 未偵測到 PreToolUse Hook，准許存取。", "text-yellow-500");
+                await new Promise(r => setTimeout(r, 600));
+                await insertStaticLine("📄 讀取檔案成功。內容: DB_PASS=super_secret_123");
+                await new Promise(r => setTimeout(r, 800));
+                await typeText("🤖 Claude: 資料庫密碼是 super_secret_123。", "text-white font-bold");
+            } else {
+                await insertStaticLine("⚡ 觸發 PreToolUse Hook (Matcher: Read)...", "text-yellow-400 font-bold");
+                await new Promise(r => setTimeout(r, 800));
+                await typeText("執行: node block_env.js", "text-gray-500");
+                await new Promise(r => setTimeout(r, 600));
+                
+                await insertStaticLine("❌ [錯誤] PreToolUse 腳本拒絕了此操作！回傳錯誤訊息至 Claude。", "text-red-500 font-bold bg-red-900/20 p-2 rounded");
+                await new Promise(r => setTimeout(r, 1000));
+                
+                await insertStaticLine("🤖 Claude 收到錯誤回饋，修正思考...", "text-blue-400 italic");
+                await new Promise(r => setTimeout(r, 800));
+                await typeText("🤖 Claude: 抱歉，我被系統阻擋，無法讀取 .env 機密檔案。", "text-white font-bold");
+            }
+
+            await new Promise(r => setTimeout(r, 500));
+            await insertStaticLine("<br>✨ 模擬結束。", "text-gray-500");
+            isSimulating = false;
+        }
+
+        // --- 模組 2: 互動式時序圖與回饋迴圈 ---
+        const flowSteps = [
+            {
+                html: `<div class="w-[33%] ml-[16.66%] border-t-[3px] border-gray-800 relative fade-in">
+                        <div class="absolute -top-8 left-1/2 transform -translate-x-1/2 whitespace-nowrap text-sm font-bold text-gray-800 bg-white border border-gray-200 px-3 py-1 rounded shadow-sm">"幫我檢查並排版 main.go"</div>
+                        <div class="absolute right-[-2px] top-[-7px] w-3 h-3 border-t-[3px] border-r-[3px] border-gray-800 transform rotate-45"></div>
+                       </div>`,
+                desc: "<strong>Step 1：</strong> 使用者向本機端的 Claude Code 送出需求，這個請求被轉發到雲端的 Claude 模型。"
+            },
+            {
+                html: `<div class="w-[33%] border-t-[3px] border-gray-400 border-dashed relative ml-[50%] fade-in">
+                        <div class="absolute -top-10 left-1/2 transform -translate-x-1/2 whitespace-nowrap text-sm text-gray-700 bg-gray-100 border border-gray-300 px-3 py-1 rounded shadow-sm text-center">決定呼叫工具<br/><span class="font-mono text-purple-600 font-bold">EditFile("main.go")</span></div>
+                        <div class="absolute left-[-2px] top-[-7px] w-3 h-3 border-b-[3px] border-l-[3px] border-gray-400 transform rotate-45"></div>
+                       </div>`,
+                desc: "<strong>Step 2：</strong> 模型判斷需要修改檔案，因此回傳一個<strong>工具調用請求 (Tool Use Request)</strong> 給本機準備執行。"
+            },
+            {
+                html: `<div class="flex justify-center z-10 fade-in">
+                        <div class="bg-red-500 text-white px-8 py-3 rounded-xl shadow-xl font-bold border-2 border-red-700 w-72 text-center transform scale-105">
+                            ⚡ 觸發 PreToolUse Hook
+                            <div class="text-xs font-normal mt-1 opacity-90">檢查權限：允許或阻擋 (Block)</div>
+                        </div>
+                       </div>`,
+                desc: "<strong>Step 3 (核心防護)：</strong> 檔案被修改前，<strong class='text-red-600'>PreToolUse</strong> 啟動。這裡可以執行安全腳本。如果腳本拒絕，流程終止並回傳錯誤給模型。"
+            },
+            {
+                html: `<div class="flex justify-center z-10 fade-in">
+                        <div class="bg-[#111] text-white px-8 py-3 rounded-xl shadow-md font-bold w-72 text-center border border-gray-800">
+                            💻 Claude Code 實際編輯檔案
+                            <div class="text-xs font-normal mt-1 text-gray-400">寫入修改內容至 main.go</div>
+                        </div>
+                       </div>`,
+                desc: "<strong>Step 4：</strong> 若未被阻擋，Claude Code 就會真正在本機執行寫入動作。"
+            },
+            {
+                html: `<div class="flex justify-center z-10 fade-in">
+                        <div class="bg-blue-500 text-white px-8 py-3 rounded-xl shadow-xl font-bold border-2 border-blue-700 w-72 text-center transform scale-105">
+                            ⚡ 觸發 PostToolUse Hook
+                            <div class="text-xs font-normal mt-1 opacity-90">加工與檢查 (如 Linter / Formatter)</div>
+                        </div>
+                       </div>`,
+                desc: "<strong>Step 5 (回饋迴圈起點)：</strong> 檔案已修改。觸發 <strong class='text-blue-600'>PostToolUse</strong>。此時無法阻擋剛才的操作，但你可以自動執行排版工具，或是跑測試。"
+            },
+            {
+                html: `<div class="w-[33%] ml-[50%] border-t-[3px] border-[#D97742] relative fade-in">
+                        <div class="absolute -top-10 left-1/2 transform -translate-x-1/2 whitespace-nowrap text-sm font-bold text-[#A64E1B] bg-[#FFF5F0] border border-[#D97742] px-3 py-1 rounded shadow-sm text-center">回傳工具執行結果<br/><span class="text-xs font-normal">+ Post Hook 的測試/檢查回饋</span></div>
+                        <div class="absolute right-[-2px] top-[-7px] w-3 h-3 border-t-[3px] border-r-[3px] border-[#D97742] transform rotate-45"></div>
+                       </div>`,
+                desc: "<strong>Step 6 (完成迴圈)：</strong> Claude Code 將執行結果，連同剛才 PostToolUse 產生的任何錯誤 Log 或回饋，一起打包送回給雲端的模型，讓模型知道是否需要根據回饋進行二次修改。"
+            }
+        ];
+
+        let currentStep = 0;
+        const container = document.getElementById('flowContainer');
+        const explanation = document.getElementById('flowExplanation');
+        const explanationBox = document.getElementById('flowExplanationBox');
+        const nextBtn = document.getElementById('nextBtn');
+
+        function nextFlowStep() {
+            if (currentStep < flowSteps.length) {
+                const stepData = flowSteps[currentStep];
+                
+                const stepDiv = document.createElement('div');
+                stepDiv.innerHTML = stepData.html;
+                container.appendChild(stepDiv.firstElementChild);
+                
+                // 更新提詞機說明 (加入淡出淡入動畫)
+                explanationBox.style.opacity = 0;
+                setTimeout(() => {
+                    explanation.innerHTML = stepData.desc;
+                    explanationBox.style.opacity = 1;
+                }, 200);
+                
+                currentStep++;
+                
+                if (currentStep === flowSteps.length) {
+                    nextBtn.disabled = true;
+                    nextBtn.classList.replace('bg-[#111]', 'bg-gray-300');
+                    nextBtn.classList.replace('hover:bg-gray-800', 'hover:bg-gray-300');
+                    nextBtn.classList.add('cursor-not-allowed');
+                    nextBtn.innerHTML = "演練完成 ✓";
+                }
+            }
+        }
+
+        function resetFlow() {
+            container.innerHTML = '';
+            currentStep = 0;
+            explanationBox.style.opacity = 0;
+            setTimeout(() => {
+                explanation.innerHTML = '請點擊右上角的「下一步」開始演練流程。如果是手機版，請左右滑動上方圖表觀看。';
+                explanationBox.style.opacity = 1;
+            }, 200);
+            
+            nextBtn.disabled = false;
+            nextBtn.classList.replace('bg-gray-300', 'bg-[#111]');
+            nextBtn.classList.replace('hover:bg-gray-300', 'hover:bg-gray-800');
+            nextBtn.classList.remove('cursor-not-allowed');
+            nextBtn.innerHTML = `下一步 <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>`;
+        }
+
+        // --- 模組 3: 檔案樹互動 ---
+        function selectFile(type) {
+            const types = ['global', 'project', 'local'];
+            
+            types.forEach(t => {
+                const navEl = document.getElementById(`file-${t}`);
+                const contentEl = document.getElementById(`file-content-${t}`);
+                
+                if (t === type) {
+                    navEl.className = 'file-active p-3 rounded-lg cursor-pointer flex items-center transition-colors text-gray-900';
+                    contentEl.classList.remove('hidden');
+                    contentEl.classList.add('fade-in');
+                } else {
+                    navEl.className = 'file-inactive p-3 rounded-lg cursor-pointer flex items-center transition-colors text-gray-600';
+                    contentEl.classList.add('hidden');
+                    contentEl.classList.remove('fade-in');
+                }
+            });
+        }
+
+        // --- 模組 4: JSON Builder 邏輯 ---
+        function generateJson() {
+            const type = document.getElementById('config-type').value;
+            const matcher = document.getElementById('config-matcher').value || "Read";
+            const command = document.getElementById('config-command').value || "echo 'hook running'";
+
+            const typeColor = type === 'PreToolUse' ? 'text-[#D16969]' : 'text-[#569CD6]';
+            const strColor = 'text-[#CE9178]';
+            const keyColor = 'text-[#9CDCFE]';
+
+            const blockContent = `
+    <span class="${typeColor}">"${type}"</span>: [
+      {
+        <span class="${keyColor}">"matcher"</span>: <span class="${strColor}">"${matcher}"</span>,
+        <span class="${keyColor}">"hooks"</span>: [
+          {
+            <span class="${keyColor}">"type"</span>: <span class="${strColor}">"command"</span>,
+            <span class="${keyColor}">"command"</span>: <span class="${strColor}">"${command}"</span>
+          }
+        ]
+      }
+    ]`;
+
+            document.getElementById('json-output').innerHTML = `{
+  <span class="${keyColor}">"hooks"</span>: {${blockContent}
+  }
+}`;
+        }
+        
+        function applyPreset(preset) {
+            const typeEl = document.getElementById('config-type');
+            const matcherEl = document.getElementById('config-matcher');
+            const commandEl = document.getElementById('config-command');
+
+            if (preset === 'block') {
+                typeEl.value = 'PreToolUse';
+                matcherEl.value = 'Read|Write|Edit';
+                commandEl.value = 'node ./scripts/block_sensitive_files.js';
+            } else if (preset === 'format') {
+                typeEl.value = 'PostToolUse';
+                matcherEl.value = 'Write|Edit';
+                commandEl.value = 'npm run prettier --write';
+            }
+            
+            [typeEl, matcherEl, commandEl].forEach(el => {
+                el.classList.add('ring-2', 'ring-[#D97742]', 'bg-[#FFF5F0]');
+                setTimeout(() => el.classList.remove('ring-2', 'ring-[#D97742]', 'bg-[#FFF5F0]'), 500);
+            });
+
+            generateJson();
+        }
+        
+        // 初始載入
+        generateJson();
+    </script>
+</body>
+</html>

--- a/public/2026-plan/section3/312001-the-claude-code-sdk.html
+++ b/public/2026-plan/section3/312001-the-claude-code-sdk.html
@@ -1,0 +1,682 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code Hooks | 終極實戰大師班</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-base: #F8F8F5;
+            --brand-dark: #1A1A1A;
+            --brand-accent: #C88A64;
+            --brand-accent-hover: #b57a55;
+        }
+        body {
+            font-family: 'Noto Sans TC', sans-serif;
+            background-color: var(--bg-base);
+            color: var(--brand-dark);
+            -webkit-font-smoothing: antialiased;
+        }
+        .font-mono { font-family: 'JetBrains Mono', monospace; }
+        
+        /* 隱藏捲軸但保持可捲動 (手機端橫向滑動救星) */
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+        .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+
+        /* Term Scrollbar */
+        .term-scroll::-webkit-scrollbar { width: 6px; height: 6px; }
+        .term-scroll::-webkit-scrollbar-track { background: transparent; }
+        .term-scroll::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.2); border-radius: 3px; }
+        .term-scroll::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.4); }
+
+        /* 動畫 */
+        .fade-in { animation: fadeIn 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards; }
+        @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+        
+        .pulse-soft { animation: pulseSoft 2s infinite; }
+        @keyframes pulseSoft { 
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+
+        /* 終端機閃爍游標 */
+        .caret-blink { animation: blink 1s step-end infinite; }
+        @keyframes blink { 50% { border-color: transparent; } }
+
+        /* 自訂選取反白顏色 */
+        ::selection { background: var(--brand-accent); color: white; }
+
+        /* 現代感卡片陰影 */
+        .card-shadow { box-shadow: 0 4px 24px -6px rgba(0, 0, 0, 0.08), 0 0 1px rgba(0,0,0,0.1); }
+    </style>
+</head>
+<body class="p-4 md:p-8 selection:bg-[#C88A64] selection:text-white">
+
+    <main class="max-w-6xl mx-auto space-y-24 pb-32">
+        
+        <!-- Hero Section -->
+        <header class="pt-16 pb-12 border-b border-gray-200 relative">
+            <div class="inline-flex items-center gap-2 bg-gray-100 border border-gray-200 text-gray-800 px-3 py-1 rounded-full text-xs font-bold tracking-widest uppercase mb-6">
+                <span class="w-2 h-2 rounded-full bg-[#C88A64] pulse-soft"></span>
+                Developer Advocate Deep Dive
+            </div>
+            <h1 class="text-5xl md:text-7xl font-black text-[#1A1A1A] leading-tight tracking-tight mb-6">
+                Claude Code Hooks<br>
+                <span class="text-[#C88A64]">底層機制與防禦實戰</span>
+            </h1>
+            <p class="text-xl text-gray-600 max-w-3xl leading-relaxed font-medium mb-10">
+                這是一份不妥協的技術指南。我們將徹底解析 <code class="bg-gray-200 px-1.5 py-0.5 rounded text-sm font-mono text-[#1A1A1A]">queries.zip</code> 專案中，如何撰寫堅不可摧的 Hooks 來阻擋 Claude 讀取機密檔案。拋棄死板的教學，請直接在下方的模擬器中驗證你的邏輯。
+            </p>
+            
+            <!-- Context Box -->
+            <div class="bg-white card-shadow rounded-2xl p-6 border border-gray-100 flex flex-col md:flex-row gap-6 items-center">
+                <div class="w-16 h-16 bg-red-50 rounded-2xl flex items-center justify-center flex-shrink-0 border border-red-100">
+                    <svg class="w-8 h-8 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path></svg>
+                </div>
+                <div>
+                    <h3 class="font-bold text-[#1A1A1A] text-lg mb-1">防禦標靶：機密檔案 .env</h3>
+                    <p class="text-gray-600 text-sm">目標環境中存在 <code class="font-mono text-red-500">SECRET_API_KEY="SUPER SECRET"</code>。我們的唯一任務，就是實作完美無瑕的 Hook 邏輯，在 Claude 觸碰它之前將其攔截。</p>
+                </div>
+            </div>
+        </header>
+
+        <!-- Step 1: Pre vs Post Lifecycle -->
+        <section class="space-y-8">
+            <div class="flex items-start gap-4">
+                <div class="w-12 h-12 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">1</div>
+                <div>
+                    <h2 class="text-3xl font-bold mb-2">時機決定命運：Pre vs Post</h2>
+                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed">
+                        防護檔案的鐵則：<strong>必須在操作發生前攔截。</strong> 許多開發者誤用 <code>PostToolUse</code> 紀錄日誌並回傳錯誤碼，卻不知道此時檔案早已被 Claude 讀取完畢。
+                    </p>
+                </div>
+            </div>
+
+            <div class="w-full overflow-x-auto no-scrollbar ml-0 md:ml-16">
+                <div class="min-w-[800px] bg-white rounded-3xl card-shadow border border-gray-100 p-2 flex gap-2">
+                    
+                    <!-- Controls -->
+                    <div class="w-1/3 p-6 flex flex-col gap-3">
+                        <div class="text-sm font-bold text-gray-400 uppercase tracking-widest mb-2">Hook Lifecycle</div>
+                        <button onclick="runStep1('pre')" id="s1-btn-pre" class="w-full text-left px-5 py-4 bg-[#1A1A1A] text-white rounded-xl font-bold shadow-md ring-2 ring-[#C88A64] ring-offset-2 transition-all">
+                            PreToolUse
+                            <span class="block text-xs font-normal text-gray-400 mt-1">執行前觸發 (可阻擋)</span>
+                        </button>
+                        <button onclick="runStep1('post')" id="s1-btn-post" class="w-full text-left px-5 py-4 bg-gray-50 text-gray-600 hover:bg-gray-100 rounded-xl font-bold border border-gray-200 transition-all">
+                            PostToolUse
+                            <span class="block text-xs font-normal text-gray-400 mt-1">執行後觸發 (僅能報錯)</span>
+                        </button>
+                        <div class="mt-auto pt-6 border-t border-gray-100">
+                            <button onclick="playStep1()" class="w-full bg-[#C88A64] hover:bg-opacity-90 text-white py-3 rounded-xl font-bold shadow transition-transform active:scale-95 flex items-center justify-center gap-2">
+                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                模擬 Claude 讀取檔案
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Animation Canvas -->
+                    <div class="w-2/3 bg-[#F8F8F5] rounded-2xl border border-gray-200 relative overflow-hidden flex flex-col items-center py-10 px-8">
+                        
+                        <div class="w-full flex justify-between items-center z-10 px-8">
+                            <div class="text-center">
+                                <div class="w-16 h-16 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center shadow-lg mx-auto mb-3">
+                                    <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                                </div>
+                                <span class="font-mono font-bold text-sm">Claude Engine</span>
+                            </div>
+
+                            <!-- Dynamic Hook Wall -->
+                            <div id="s1-hook-wall" class="absolute left-1/2 top-1/2 -translate-y-1/2 -translate-x-1/2 flex flex-col items-center transition-all duration-700 ease-in-out z-20">
+                                <div id="s1-shield" class="w-20 h-24 bg-[#C88A64] rounded-xl flex items-center justify-center shadow-2xl border-4 border-white">
+                                    <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
+                                </div>
+                                <div class="bg-[#1A1A1A] text-white text-xs font-mono px-3 py-1 rounded-full mt-2 font-bold shadow-md" id="s1-hook-label">PreToolUse</div>
+                            </div>
+
+                            <div class="text-center relative">
+                                <div id="s1-target-file" class="w-16 h-16 bg-white border-2 border-gray-300 text-gray-500 rounded-2xl flex items-center justify-center shadow-sm mx-auto mb-3 transition-colors duration-300">
+                                    <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                                </div>
+                                <span class="font-mono font-bold text-sm">.env</span>
+                            </div>
+                        </div>
+
+                        <!-- Data Track -->
+                        <div class="absolute top-1/2 left-24 right-24 h-[2px] bg-gray-200 -translate-y-1/2 z-0"></div>
+                        
+                        <!-- Moving Packet -->
+                        <div id="s1-packet" class="absolute top-1/2 left-24 w-4 h-4 rounded-full bg-[#1A1A1A] -translate-y-1/2 -ml-2 opacity-0 z-10 transition-all duration-[800ms] ease-in-out shadow-[0_0_10px_rgba(26,26,26,0.5)]"></div>
+
+                        <!-- Verdict Feedback -->
+                        <div id="s1-feedback" class="absolute bottom-6 left-1/2 -translate-x-1/2 bg-white px-6 py-3 rounded-xl shadow-xl border border-gray-100 text-sm font-bold opacity-0 transition-opacity flex items-center gap-2">
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Step 2: Determine Tools (Dynamic MCP) -->
+        <section class="space-y-8">
+            <div class="flex items-start gap-4">
+                <div class="w-12 h-12 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">2</div>
+                <div>
+                    <h2 class="text-3xl font-bold mb-2">鎖定目標工具：隱蔽的 Grep 與動態 MCP</h2>
+                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed">
+                        防禦網的第二步是定義要攔截的 <code>tool_name</code>。除了直覺的 <code>Read</code>，開發者極常漏掉 <strong><code>Grep</code></strong>（搜尋內容等同讀取內容）。另外，由於 MCP Servers 會動態注入工具，最佳實踐是直接透過終端機探測。
+                    </p>
+                </div>
+            </div>
+
+            <div class="w-full overflow-x-auto no-scrollbar ml-0 md:ml-16">
+                <div class="min-w-[900px] flex gap-6">
+                    
+                    <!-- Code/Table Hybrid -->
+                    <div class="w-[45%] bg-white rounded-3xl card-shadow border border-gray-100 overflow-hidden flex flex-col">
+                        <div class="bg-[#1A1A1A] px-5 py-4 text-white font-mono text-sm flex justify-between items-center">
+                            <span>Target Tools (Watchlist)</span>
+                            <span class="bg-red-500 bg-opacity-20 text-red-300 px-2 py-0.5 rounded text-xs">High Risk</span>
+                        </div>
+                        <div class="p-6 flex-1 bg-gray-50">
+                            <ul class="space-y-4 font-mono text-sm">
+                                <li class="bg-white border border-gray-200 p-4 rounded-xl shadow-sm flex justify-between items-start border-l-4 border-l-red-500">
+                                    <div>
+                                        <div class="font-bold text-red-600 mb-1">"Read"</div>
+                                        <div class="text-gray-500 text-xs font-sans">直接讀取指定檔案的所有內容。</div>
+                                    </div>
+                                    <svg class="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
+                                </li>
+                                <li class="bg-white border border-gray-200 p-4 rounded-xl shadow-sm flex justify-between items-start border-l-4 border-l-red-500">
+                                    <div>
+                                        <div class="font-bold text-red-600 mb-1">"Grep"</div>
+                                        <div class="text-gray-500 text-xs font-sans">搜尋檔案內容。<strong class="text-red-500">邊緣案例：</strong> 若 Claude 搜尋 <code>API_KEY</code>，一樣會把機密回傳給 LLM。</div>
+                                    </div>
+                                    <svg class="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
+                                </li>
+                                <li class="bg-white border border-gray-200 p-4 rounded-xl shadow-sm flex justify-between items-center opacity-60">
+                                    <div class="font-bold text-gray-700">"Bash", "Glob", "Edit"...</div>
+                                    <div class="text-gray-400 text-xs font-sans">(根據需求決定是否攔截)</div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <!-- Terminal Emulator -->
+                    <div class="w-[55%] bg-[#1A1A1A] rounded-3xl card-shadow border border-gray-800 flex flex-col overflow-hidden">
+                        <div class="bg-black bg-opacity-40 px-4 py-3 flex items-center gap-2 border-b border-gray-800">
+                            <div class="w-3 h-3 rounded-full bg-red-500"></div>
+                            <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
+                            <div class="w-3 h-3 rounded-full bg-green-500"></div>
+                            <span class="ml-4 text-xs font-mono text-gray-500">探測動態工具清單</span>
+                        </div>
+                        <div class="p-6 font-mono text-sm text-gray-300 flex-1 overflow-y-auto term-scroll" id="s2-term">
+                            <div class="text-green-400 mb-2">➜ queries git:(dev) ✗ <span class="text-white">claude</span></div>
+                            <div class="mb-6"><span class="text-[#C88A64]">></span> <span class="text-gray-500 border-b border-gray-500 border-dotted cursor-pointer hover:text-white transition-colors" onclick="runS2Term()">點擊此處自動輸入探測指令</span><span class="border-r-2 border-white ml-0.5 caret-blink"></span></div>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </section>
+
+        <!-- Step 3: Parse Standard In -->
+        <section class="space-y-8">
+            <div class="flex items-start gap-4">
+                <div class="w-12 h-12 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">3</div>
+                <div>
+                    <h2 class="text-3xl font-bold mb-2">解析 Standard In (JSON Payload Diff)</h2>
+                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed">
+                        Hook 觸發時，Claude 會將 JSON 資料注入到腳本的 <code>Standard In (stdin)</code>。防禦腳本最常犯的錯就是**沒有正確處理屬性差異**。比較下方 <code>Read</code> 與 <code>Grep</code> 的結構差異。
+                    </p>
+                </div>
+            </div>
+
+            <div class="w-full overflow-x-auto no-scrollbar ml-0 md:ml-16">
+                <div class="min-w-[900px] bg-[#1A1A1A] rounded-3xl card-shadow border border-gray-800 overflow-hidden flex flex-col">
+                    
+                    <!-- Diff Tabs -->
+                    <div class="flex bg-black bg-opacity-50 border-b border-gray-800">
+                        <button onclick="setDiff('read')" id="btn-diff-read" class="px-6 py-4 font-mono text-sm font-bold text-white border-b-2 border-[#C88A64] transition-colors">
+                            Read Payload (常規)
+                        </button>
+                        <button onclick="setDiff('grep')" id="btn-diff-grep" class="px-6 py-4 font-mono text-sm font-bold text-gray-500 border-b-2 border-transparent hover:text-gray-300 transition-colors">
+                            Grep Payload (邊緣案例)
+                        </button>
+                    </div>
+
+                    <!-- Diff Content -->
+                    <div class="p-8 font-mono text-sm leading-relaxed relative min-h-[280px]">
+                        <!-- Common part -->
+                        <div class="text-gray-400">{</div>
+                        <div class="text-gray-400 pl-4">"session_id": "2d6a1e4d-6...",</div>
+                        <div class="text-gray-400 pl-4">"hook_event_name": "PreToolUse",</div>
+                        
+                        <!-- Changing part wrapper -->
+                        <div id="diff-content" class="transition-all duration-300">
+                            <!-- Injected by JS -->
+                        </div>
+
+                        <div class="text-gray-400">}</div>
+                        
+                        <!-- Note -->
+                        <div class="absolute bottom-6 right-8 bg-[#C88A64] bg-opacity-10 border border-[#C88A64] text-[#C88A64] px-4 py-3 rounded-xl text-xs max-w-sm flex gap-3 items-start">
+                            <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                            <p id="diff-note">你的解析器必須擷取 <code>file_path</code> 來檢查是否為敏感檔案。</p>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </section>
+
+        <!-- Step 4: Exit Codes & Logic Builder -->
+        <section class="space-y-8">
+            <div class="flex items-start gap-4">
+                <div class="w-12 h-12 bg-[#C88A64] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">4</div>
+                <div class="flex-1">
+                    <h2 class="text-3xl font-bold mb-2">決策與反饋：防禦腳本編譯與測試實驗室</h2>
+                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed mb-6">
+                        之前的設計確實違反直覺，因為它把「寫腳本」跟「執行測試」混在一起了！<br>
+                        好的開發者體驗應該是：<strong>先設定好你的防禦邏輯 (Script Builder)，再丟入不同的檔案來進行測試 (Test Lab)。</strong>
+                    </p>
+                    
+                    <div class="w-full overflow-x-auto no-scrollbar flex flex-col gap-6">
+                        
+                        <!-- Top: Script Builder -->
+                        <div class="min-w-[950px] bg-white rounded-3xl card-shadow border border-gray-200 flex overflow-hidden">
+                            <!-- Left: Configuration Panel -->
+                            <div class="w-[45%] bg-gray-50 border-r border-gray-200 flex flex-col">
+                                <div class="px-6 py-4 border-b border-gray-200 bg-white font-bold text-gray-800 flex items-center justify-between">
+                                    <span>1. 腳本邏輯設定 (Script Builder)</span>
+                                </div>
+                                <div class="p-6 flex-1 space-y-6">
+                                    
+                                    <div>
+                                        <label class="block text-sm font-bold text-gray-700 mb-2">A. 攔截條件 (If matches):</label>
+                                        <select id="s4-if-cond" onchange="updateScriptPreview()" class="w-full bg-white border-2 border-gray-200 rounded-xl px-4 py-3 text-sm font-mono focus:border-[#C88A64] outline-none">
+                                            <option value="env">*".env"* (僅攔截機密檔案)</option>
+                                            <option value="all">"*" (攔截所有檔案)</option>
+                                        </select>
+                                    </div>
+
+                                    <div>
+                                        <label class="block text-sm font-bold text-gray-700 mb-2">B. 條件成立時的動作 (Action):</label>
+                                        <div class="flex bg-white border-2 border-gray-200 rounded-xl overflow-hidden text-sm font-mono">
+                                            <button id="s4-btn-exit2" onclick="setIfExit(2)" class="flex-1 py-3 bg-red-50 text-red-700 font-bold border-r-2 border-gray-200 transition-colors">Exit 2 (Block)</button>
+                                            <button id="s4-btn-exit0" onclick="setIfExit(0)" class="flex-1 py-3 text-gray-500 hover:bg-gray-50 transition-colors">Exit 0 (Allow)</button>
+                                        </div>
+                                    </div>
+
+                                    <div id="s4-stderr-container">
+                                        <label class="block text-sm font-bold text-gray-700 mb-2">C. 拒絕理由 (Stderr feedback):</label>
+                                        <input type="text" id="s4-stderr" value="Access Denied: .env files are restricted." onkeyup="updateScriptPreview()" class="w-full bg-white border-2 border-gray-200 rounded-xl px-4 py-3 text-sm font-mono focus:border-[#C88A64] outline-none">
+                                    </div>
+
+                                    <div class="pt-4 border-t border-gray-200">
+                                        <label class="block text-sm font-bold text-gray-700 mb-2">D. 預設行為 (Default Action):</label>
+                                        <select id="s4-def-exit" onchange="updateScriptPreview()" class="w-full bg-white border-2 border-gray-200 rounded-xl px-4 py-3 text-sm font-mono focus:border-[#C88A64] outline-none">
+                                            <option value="0">Exit 0 (預設放行其餘檔案)</option>
+                                            <option value="2">Exit 2 (預設全面封殺)</option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Right: Live Code Preview -->
+                            <div class="w-[55%] flex flex-col bg-[#1A1A1A] text-gray-300 font-mono text-[13px]">
+                                <div class="px-5 py-3 border-b border-gray-800 flex justify-between bg-black bg-opacity-40">
+                                    <span class="text-gray-400">hook_script.sh (即時編譯)</span>
+                                    <span class="text-[#C88A64]">Bash</span>
+                                </div>
+                                <div class="p-6 flex-1 bg-[#1A1A1A] leading-relaxed relative">
+                                    <div class="text-gray-500 italic mb-4"># Extract path from stdin</div>
+                                    <div class="text-blue-400">TARGET_PATH<span class="text-white">=</span><span class="text-gray-400">$(cat - | jq -r '.tool_input.file_path')</span></div>
+                                    <br>
+                                    
+                                    <!-- Dynamic IF Block -->
+                                    <div class="relative">
+                                        <div id="live-if-strip" class="absolute -left-4 top-0 bottom-0 w-1 bg-[#C88A64] opacity-50 rounded-r"></div>
+                                        <div class="text-purple-400">if <span class="text-white">[[</span> <span class="text-gray-300">"$TARGET_PATH"</span> <span class="text-white">==</span> <span class="text-green-300" id="live-if-cond">*".env"*</span> <span class="text-white">]];</span> then</div>
+                                        <div id="live-stderr-block" class="pl-4 mt-1">
+                                            <span class="text-blue-300">echo</span> <span class="text-green-300">"<span id="live-stderr-text">Access Denied: .env files are restricted.</span>"</span> <span class="text-red-400">>&2</span>
+                                        </div>
+                                        <div class="pl-4 mt-1">
+                                            <span class="text-blue-300">exit</span> <span id="live-if-exit" class="text-red-400 font-bold">2</span>
+                                        </div>
+                                        <div class="text-purple-400">fi</div>
+                                    </div>
+
+                                    <br>
+                                    <div class="text-gray-500 italic"># Default behavior</div>
+                                    <div class="text-blue-300">exit <span id="live-def-exit" class="text-green-400 font-bold">0</span></div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Bottom: Test Lab -->
+                        <div class="min-w-[950px] bg-[#1A1A1A] rounded-3xl card-shadow border border-gray-800 overflow-hidden flex flex-col">
+                            <div class="bg-gray-900 px-6 py-4 border-b border-gray-800 flex items-center justify-between">
+                                <span class="font-bold text-white">2. 測試實驗室 (Test Lab)</span>
+                            </div>
+                            <div class="flex p-6 gap-6">
+                                <div class="w-1/3 flex flex-col gap-4">
+                                    <div class="text-sm font-mono text-gray-400 mb-2">請選擇模擬輸入檔案：</div>
+                                    <button onclick="runTest('danger')" class="w-full bg-red-900 bg-opacity-20 hover:bg-opacity-40 border border-red-800 text-red-300 font-bold py-4 rounded-xl transition-all text-sm font-mono flex flex-col items-center gap-1">
+                                        <span>[ 測試讀取 .env ]</span>
+                                        <span class="text-[10px] font-normal text-red-400/60">應觸發攔截規則</span>
+                                    </button>
+                                    <button onclick="runTest('safe')" class="w-full bg-green-900 bg-opacity-20 hover:bg-opacity-40 border border-green-800 text-green-300 font-bold py-4 rounded-xl transition-all text-sm font-mono flex flex-col items-center gap-1">
+                                        <span>[ 測試讀取 package.json ]</span>
+                                        <span class="text-[10px] font-normal text-green-400/60">應觸發預設規則</span>
+                                    </button>
+                                </div>
+                                <div class="w-2/3 bg-black rounded-xl border border-gray-800 flex flex-col">
+                                    <div class="px-4 py-2 text-[11px] text-gray-500 border-b border-gray-800 uppercase tracking-widest">Claude Context Engine Output</div>
+                                    <div id="s4-term-out" class="p-4 overflow-y-auto term-scroll flex-1 text-xs font-mono space-y-1.5 h-48">
+                                        <div class="text-gray-600">等待測試觸發...</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <script>
+        // --- Step 1: Pre vs Post Animation ---
+        let s1Type = 'pre';
+        function runStep1(type) {
+            s1Type = type;
+            const btnPre = document.getElementById('s1-btn-pre');
+            const btnPost = document.getElementById('s1-btn-post');
+            const hookWall = document.getElementById('s1-hook-wall');
+            const shield = document.getElementById('s1-shield');
+            const label = document.getElementById('s1-hook-label');
+            const targetFile = document.getElementById('s1-target-file');
+
+            // Reset UI
+            targetFile.className = 'w-16 h-16 bg-white border-2 border-gray-300 text-gray-500 rounded-2xl flex items-center justify-center shadow-sm mx-auto mb-3 transition-colors duration-300';
+            document.getElementById('s1-packet').style.opacity = '0';
+            document.getElementById('s1-packet').style.left = '24px';
+            const feedback = document.getElementById('s1-feedback');
+            feedback.style.opacity = '0';
+            feedback.className = 'absolute bottom-6 left-1/2 -translate-x-1/2 bg-white px-6 py-3 rounded-xl shadow-xl border border-gray-100 text-sm font-bold opacity-0 transition-opacity flex items-center gap-2';
+
+
+            if(type === 'pre') {
+                btnPre.className = 'w-full text-left px-5 py-4 bg-[#1A1A1A] text-white rounded-xl font-bold shadow-md ring-2 ring-[#C88A64] ring-offset-2 transition-all';
+                btnPost.className = 'w-full text-left px-5 py-4 bg-gray-50 text-gray-600 hover:bg-gray-100 rounded-xl font-bold border border-gray-200 transition-all';
+                
+                // Position wall in the middle
+                hookWall.style.left = '50%';
+                shield.className = 'w-20 h-24 bg-[#C88A64] rounded-xl flex items-center justify-center shadow-2xl border-4 border-white transition-colors duration-300';
+                label.innerText = 'PreToolUse';
+            } else {
+                btnPost.className = 'w-full text-left px-5 py-4 bg-[#1A1A1A] text-white rounded-xl font-bold shadow-md ring-2 ring-[#C88A64] ring-offset-2 transition-all';
+                btnPre.className = 'w-full text-left px-5 py-4 bg-gray-50 text-gray-600 hover:bg-gray-100 rounded-xl font-bold border border-gray-200 transition-all';
+                
+                // Position wall AFTER the file
+                hookWall.style.left = '85%';
+                shield.className = 'w-20 h-24 bg-gray-400 rounded-xl flex items-center justify-center shadow-2xl border-4 border-white transition-colors duration-300';
+                label.innerText = 'PostToolUse';
+            }
+        }
+
+        function playStep1() {
+            const packet = document.getElementById('s1-packet');
+            const targetFile = document.getElementById('s1-target-file');
+            const feedback = document.getElementById('s1-feedback');
+            const shield = document.getElementById('s1-shield');
+            
+            // Reset
+            packet.style.transition = 'none';
+            packet.style.left = '10%';
+            packet.style.opacity = '1';
+            feedback.style.opacity = '0';
+            targetFile.className = 'w-16 h-16 bg-white border-2 border-gray-300 text-gray-500 rounded-2xl flex items-center justify-center shadow-sm mx-auto mb-3 transition-colors duration-300';
+
+            // Trigger reflow
+            void packet.offsetWidth;
+            packet.style.transition = 'all 800ms ease-in-out';
+
+            if(s1Type === 'pre') {
+                packet.style.left = '45%'; // hits the wall
+                setTimeout(() => {
+                    shield.classList.replace('bg-[#C88A64]', 'bg-red-500');
+                    setTimeout(() => shield.classList.replace('bg-red-500', 'bg-[#C88A64]'), 500);
+                    
+                    feedback.innerHTML = '<span class="w-3 h-3 rounded-full bg-green-500"></span><span class="text-green-600">成功在讀取前攔截操作！檔案安全。</span>';
+                    feedback.style.opacity = '1';
+                    packet.style.opacity = '0';
+                }, 800);
+            } else {
+                packet.style.left = '100%'; // passes through
+                setTimeout(() => {
+                    targetFile.classList.replace('border-gray-300', 'border-red-500');
+                    targetFile.classList.replace('text-gray-500', 'text-red-500');
+                    targetFile.classList.add('bg-red-50');
+                }, 500); // changes color as packet passes
+
+                setTimeout(() => {
+                    shield.classList.replace('bg-gray-400', 'bg-red-500');
+                    setTimeout(() => shield.classList.replace('bg-red-500', 'bg-gray-400'), 500);
+
+                    feedback.innerHTML = '<span class="w-3 h-3 rounded-full bg-red-500"></span><span class="text-red-600">嚴重：檔案已被讀取！PostToolUse 攔截無效。</span>';
+                    feedback.style.opacity = '1';
+                    packet.style.opacity = '0';
+                }, 800);
+            }
+        }
+        runStep1('pre'); // Init
+
+
+        // --- Step 2: Terminal Typing ---
+        let s2IsTyping = false;
+        async function runS2Term() {
+            if(s2IsTyping) return;
+            s2IsTyping = true;
+            const term = document.getElementById('s2-term');
+            term.innerHTML = '<div class="text-green-400 mb-2">➜ queries git:(dev) ✗ <span class="text-white">claude</span></div>';
+            
+            const promptLine = document.createElement('div');
+            promptLine.className = 'mb-4 text-white';
+            promptLine.innerHTML = '<span class="text-[#C88A64]">></span> <span id="s2-type-target"></span><span class="border-r-2 border-white ml-0.5 caret-blink"></span>';
+            term.appendChild(promptLine);
+
+            const target = document.getElementById('s2-type-target');
+            const msg = "List out the names of all the tools you have access to, bullet point list.";
+            for(let i=0; i<msg.length; i++){
+                target.innerHTML += msg[i];
+                await new Promise(r => setTimeout(r, 20)); // typing speed
+            }
+
+            const thinkingLine = document.createElement('div');
+            thinkingLine.className = 'text-gray-500 italic mb-4 mt-2';
+            thinkingLine.innerText = '* Imagining...';
+            term.appendChild(thinkingLine);
+            await new Promise(r => setTimeout(r, 600));
+            thinkingLine.remove();
+
+            const output = document.createElement('div');
+            output.className = 'text-gray-300 fade-in space-y-2 pb-6';
+            output.innerHTML = `
+                <p>Here are the tools I have access to:</p>
+                <ul class="list-disc pl-5 font-mono">
+                    <li>Bash</li>
+                    <li class="bg-red-900 bg-opacity-30 text-red-200 inline-block px-1 rounded my-1 font-bold">Grep  <span class="text-xs font-normal text-red-400 ml-2">&lt;- ⚠️ Danger: File Access</span></li>
+                    <br>
+                    <li>Edit</li>
+                    <li class="bg-[#C88A64] bg-opacity-20 text-[#C88A64] inline-block px-1 rounded my-1 font-bold">Read  <span class="text-xs font-normal text-[#C88A64] ml-2">&lt;- 🎯 Target: File Access</span></li>
+                    <br>
+                    <li>Write</li>
+                    <li class="text-purple-400">MCP_Server_GitSearch</li>
+                    <li class="text-purple-400">MCP_Server_DBQuery</li>
+                </ul>
+                <p class="text-gray-500 text-xs mt-4 border-t border-gray-800 pt-2">/* 工具清單是動態的，依賴你掛載的 MCP Servers */</p>
+            `;
+            term.appendChild(output);
+            term.scrollTop = term.scrollHeight;
+            s2IsTyping = false;
+        }
+
+        // --- Step 3: JSON Diff ---
+        const diffPayloads = {
+            read: `
+<div class="text-[#C88A64] pl-4 font-bold">"tool_name": <span class="text-yellow-300">"Read"</span>,</div>
+<div class="text-[#C88A64] pl-4 font-bold">"tool_input": {</div>
+<div class="pl-8 bg-[#1A1A1A] border-l-2 border-[#C88A64] py-1 my-1 flex items-center">
+    <span class="text-blue-300">"file_path"</span><span class="text-gray-400">: </span><span class="text-green-300">"/code/queries/.env"</span>
+</div>
+<div class="text-[#C88A64] pl-4 font-bold">}</div>`,
+            grep: `
+<div class="text-[#C88A64] pl-4 font-bold">"tool_name": <span class="text-yellow-300">"Grep"</span>,</div>
+<div class="text-[#C88A64] pl-4 font-bold">"tool_input": {</div>
+<div class="pl-8 py-1"><span class="text-blue-300">"pattern"</span><span class="text-gray-400">: </span><span class="text-green-300">"SECRET"</span>,</div>
+<div class="pl-8 bg-[#1A1A1A] border-l-2 border-red-500 py-1 my-1 flex items-center">
+    <span class="text-blue-300">"target_path"</span><span class="text-gray-400">: </span><span class="text-green-300">"/code/queries/.env"</span>
+</div>
+<div class="text-[#C88A64] pl-4 font-bold">}</div>`
+        };
+
+        function setDiff(type) {
+            const btnR = document.getElementById('btn-diff-read');
+            const btnG = document.getElementById('btn-diff-grep');
+            const content = document.getElementById('diff-content');
+            const note = document.getElementById('diff-note');
+
+            content.classList.remove('fade-in');
+            void content.offsetWidth; // trigger reflow
+
+            if(type === 'read') {
+                btnR.className = 'px-6 py-4 font-mono text-sm font-bold text-white border-b-2 border-[#C88A64] transition-colors';
+                btnG.className = 'px-6 py-4 font-mono text-sm font-bold text-gray-500 border-b-2 border-transparent hover:text-gray-300 transition-colors';
+                note.innerHTML = '解析器必須擷取 <code>file_path</code> 來檢查是否為敏感檔案。';
+            } else {
+                btnG.className = 'px-6 py-4 font-mono text-sm font-bold text-white border-b-2 border-red-500 transition-colors';
+                btnR.className = 'px-6 py-4 font-mono text-sm font-bold text-gray-500 border-b-2 border-transparent hover:text-gray-300 transition-colors';
+                note.innerHTML = '<strong>陷阱！</strong> 在 Grep 工具中，路徑屬性變成了 <code>target_path</code>，而非 <code>file_path</code>。腳本必須相容處理。';
+            }
+
+            content.innerHTML = diffPayloads[type];
+            content.classList.add('fade-in');
+        }
+        setDiff('read'); // Init
+
+        // --- Step 4: Logic Builder & Execution ---
+        let currentIfExit = 2;
+        
+        function setIfExit(code) {
+            currentIfExit = code;
+            const btn2 = document.getElementById('s4-btn-exit2');
+            const btn0 = document.getElementById('s4-btn-exit0');
+            const stderrContainer = document.getElementById('s4-stderr-container');
+
+            if(code === 2) {
+                btn2.className = 'flex-1 py-3 bg-red-50 text-red-700 font-bold border-r-2 border-gray-200 transition-colors';
+                btn0.className = 'flex-1 py-3 text-gray-500 hover:bg-gray-50 transition-colors';
+                stderrContainer.style.opacity = '1';
+                stderrContainer.style.pointerEvents = 'auto';
+            } else {
+                btn0.className = 'flex-1 py-3 bg-gray-200 text-gray-800 font-bold transition-colors';
+                btn2.className = 'flex-1 py-3 text-gray-500 hover:bg-gray-50 border-r-2 border-gray-200 transition-colors';
+                stderrContainer.style.opacity = '0.4';
+                stderrContainer.style.pointerEvents = 'none';
+            }
+            updateScriptPreview();
+        }
+
+        function updateScriptPreview() {
+            const ifCond = document.getElementById('s4-if-cond').value;
+            const stderrVal = document.getElementById('s4-stderr').value;
+            const defExit = document.getElementById('s4-def-exit').value;
+
+            // Cond
+            document.getElementById('live-if-cond').innerText = ifCond === 'env' ? '*".env"*' : '"*"';
+            
+            // Exit in IF
+            const liveIfExit = document.getElementById('live-if-exit');
+            const liveStderrBlock = document.getElementById('live-stderr-block');
+            const liveIfStrip = document.getElementById('live-if-strip');
+
+            document.getElementById('live-stderr-text').innerText = stderrVal;
+
+            if (currentIfExit === 2) {
+                liveIfExit.innerText = '2';
+                liveIfExit.className = 'text-red-400 font-bold';
+                liveStderrBlock.style.opacity = '1';
+                liveIfStrip.className = 'absolute -left-4 top-0 bottom-0 w-1 bg-[#C88A64] opacity-50 rounded-r';
+            } else {
+                liveIfExit.innerText = '0';
+                liveIfExit.className = 'text-green-400 font-bold';
+                liveStderrBlock.style.opacity = '0.3';
+                liveIfStrip.className = 'absolute -left-4 top-0 bottom-0 w-1 bg-yellow-500 opacity-50 rounded-r';
+            }
+
+            // Default Exit
+            const liveDefExit = document.getElementById('live-def-exit');
+            liveDefExit.innerText = defExit;
+            liveDefExit.className = defExit === '0' ? 'text-green-400 font-bold' : 'text-red-400 font-bold';
+        }
+
+        function runTest(testType) {
+            const ifCond = document.getElementById('s4-if-cond').value;
+            const defExit = document.getElementById('s4-def-exit').value;
+            const stderrVal = document.getElementById('s4-stderr').value;
+            
+            const targetPath = testType === 'danger' ? '/code/queries/.env' : '/code/queries/package.json';
+            const term = document.getElementById('s4-term-out');
+            
+            term.innerHTML = '';
+            const log = (html, delay) => {
+                setTimeout(() => {
+                    const el = document.createElement('div');
+                    el.innerHTML = html;
+                    el.className = 'fade-in';
+                    term.appendChild(el);
+                    term.scrollTop = term.scrollHeight;
+                }, delay);
+            }
+
+            log('<span class="text-blue-400">></span> 注入輸入：<code>TARGET_PATH="' + targetPath + '"</code>', 100);
+            log('<span class="text-gray-500">></span> 執行腳本檢測...', 400);
+
+            let isMatch = false;
+            if (ifCond === 'all') {
+                isMatch = true;
+            } else if (ifCond === 'env' && testType === 'danger') {
+                isMatch = true;
+            }
+
+            if (isMatch) {
+                log('<span class="text-purple-400">> 條件成立，進入 if 區塊。</span>', 800);
+                
+                if (currentIfExit === 2) {
+                    log('<span class="text-red-400">> 觸發 exit 2 (中斷)</span>', 1200);
+                    log('<div class="mt-2 bg-red-900/30 border border-red-800 p-2 rounded text-red-200 font-bold">[TOOL BLOCKED] Claude 操作已被成功阻擋！</div>', 1600);
+                    log('<div class="mt-1 text-[#C88A64]">Claude 收到回饋: <span class="text-gray-300">"' + stderrVal + '"</span></div>', 1800);
+                } else {
+                    log('<span class="text-green-400">> 觸發 exit 0 (放行)</span>', 1200);
+                    log('<div class="mt-2 bg-yellow-900/30 border border-yellow-800 p-2 rounded text-yellow-200 font-bold">⚠️ [邏輯漏洞] 你攔截了檔案卻設定放行！</div>', 1600);
+                    log('<div class="mt-1 text-green-400 font-bold">[ALL IS WELL] Claude 成功讀取檔案。 (可能導致機密外洩)</div>', 1800);
+                }
+            } else {
+                log('<span class="text-gray-500">> 條件不成立，跳過 if 區塊。</span>', 800);
+                
+                if (defExit === '0') {
+                    log('<span class="text-green-400">> 腳本結束，觸發預設 exit 0</span>', 1200);
+                    log('<div class="mt-2 bg-green-900/20 border border-green-800 p-2 rounded text-green-400 font-bold">[ALL IS WELL] 正常檔案已被放行，操作繼續。</div>', 1600);
+                } else {
+                    log('<span class="text-red-400">> 腳本結束，觸發預設 exit 2</span>', 1200);
+                    log('<div class="mt-2 bg-red-900/30 border border-red-800 p-2 rounded text-red-200 font-bold">[TOOL BLOCKED] 檔案被預設防禦規則阻擋。</div>', 1600);
+                }
+            }
+        }
+    </script>
+</body>
+</html>

--- a/public/2026-plan/section3/312001-the-claude-code-sdk.html
+++ b/public/2026-plan/section3/312001-the-claude-code-sdk.html
@@ -1,682 +1,388 @@
 <!DOCTYPE html>
-<html lang="zh-TW">
+<html lang="zh-TW" class="scroll-smooth">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Claude Code Hooks | 終極實戰大師班</title>
+    <title>Claude Code SDK | 秒懂白話文解析</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <link
+        href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Noto+Sans+TC:wght@400;500;700;900&display=swap"
+        rel="stylesheet">
+
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['"Noto Sans TC"', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'monospace'],
+                    },
+                    colors: {
+                        // 強制鎖死品牌配色
+                        themeBg: '#F8F8F5',
+                        themeDark: '#1A1A1A',
+                        themeAccent: '#C88A64',
+                        themeAccentHover: '#B57855',
+                        themeCode: '#242424',
+                    }
+                }
+            }
+        }
+    </script>
+
     <style>
-        :root {
-            --bg-base: #F8F8F5;
-            --brand-dark: #1A1A1A;
-            --brand-accent: #C88A64;
-            --brand-accent-hover: #b57a55;
-        }
         body {
-            font-family: 'Noto Sans TC', sans-serif;
-            background-color: var(--bg-base);
-            color: var(--brand-dark);
-            -webkit-font-smoothing: antialiased;
-        }
-        .font-mono { font-family: 'JetBrains Mono', monospace; }
-        
-        /* 隱藏捲軸但保持可捲動 (手機端橫向滑動救星) */
-        .no-scrollbar::-webkit-scrollbar { display: none; }
-        .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
-
-        /* Term Scrollbar */
-        .term-scroll::-webkit-scrollbar { width: 6px; height: 6px; }
-        .term-scroll::-webkit-scrollbar-track { background: transparent; }
-        .term-scroll::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.2); border-radius: 3px; }
-        .term-scroll::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.4); }
-
-        /* 動畫 */
-        .fade-in { animation: fadeIn 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards; }
-        @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
-        
-        .pulse-soft { animation: pulseSoft 2s infinite; }
-        @keyframes pulseSoft { 
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.5; }
+            background-color: #F8F8F5;
+            color: #1A1A1A;
         }
 
-        /* 終端機閃爍游標 */
-        .caret-blink { animation: blink 1s step-end infinite; }
-        @keyframes blink { 50% { border-color: transparent; } }
+        /* 橫向防呆 */
+        .no-scrollbar::-webkit-scrollbar {
+            display: none;
+        }
 
-        /* 自訂選取反白顏色 */
-        ::selection { background: var(--brand-accent); color: white; }
+        .no-scrollbar {
+            -ms-overflow-style: none;
+            scrollbar-width: none;
+        }
 
-        /* 現代感卡片陰影 */
-        .card-shadow { box-shadow: 0 4px 24px -6px rgba(0, 0, 0, 0.08), 0 0 1px rgba(0,0,0,0.1); }
+        /* 淡入動畫 (給對話泡泡用) */
+        .fade-in-up {
+            animation: fadeInUp 0.4s ease-out forwards;
+            opacity: 0;
+            transform: translateY(10px);
+        }
+
+        @keyframes fadeInUp {
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        /* Loading 點點點動畫 */
+        .loading-dots:after {
+            content: '.';
+            animation: dots 1.5s steps(5, end) infinite;
+        }
+
+        @keyframes dots {
+
+            0%,
+            20% {
+                color: rgba(0, 0, 0, 0);
+                text-shadow: .25em 0 0 rgba(0, 0, 0, 0), .5em 0 0 rgba(0, 0, 0, 0);
+            }
+
+            40% {
+                color: currentColor;
+                text-shadow: .25em 0 0 rgba(0, 0, 0, 0), .5em 0 0 rgba(0, 0, 0, 0);
+            }
+
+            60% {
+                text-shadow: .25em 0 0 currentColor, .5em 0 0 rgba(0, 0, 0, 0);
+            }
+
+            80%,
+            100% {
+                text-shadow: .25em 0 0 currentColor, .5em 0 0 currentColor;
+            }
+        }
     </style>
 </head>
-<body class="p-4 md:p-8 selection:bg-[#C88A64] selection:text-white">
 
-    <main class="max-w-6xl mx-auto space-y-24 pb-32">
-        
-        <!-- Hero Section -->
-        <header class="pt-16 pb-12 border-b border-gray-200 relative">
-            <div class="inline-flex items-center gap-2 bg-gray-100 border border-gray-200 text-gray-800 px-3 py-1 rounded-full text-xs font-bold tracking-widest uppercase mb-6">
-                <span class="w-2 h-2 rounded-full bg-[#C88A64] pulse-soft"></span>
-                Developer Advocate Deep Dive
+<body class="font-sans leading-relaxed pb-32">
+
+    <!-- Header -->
+    <header class="w-full bg-themeDark text-themeBg py-20 px-6 shadow-xl">
+        <div class="max-w-4xl mx-auto">
+            <div
+                class="inline-block px-3 py-1 bg-themeAccent/20 border border-themeAccent/50 text-themeAccent rounded-full text-xs font-mono mb-4 tracking-widest uppercase">
+                Developer Advocate Guide
             </div>
-            <h1 class="text-5xl md:text-7xl font-black text-[#1A1A1A] leading-tight tracking-tight mb-6">
-                Claude Code Hooks<br>
-                <span class="text-[#C88A64]">底層機制與防禦實戰</span>
+            <h1 class="text-4xl md:text-5xl font-black tracking-tight leading-tight mb-4">
+                白話文圖解：<br>
+                <span class="text-themeAccent">Claude Code SDK 底層邏輯</span>
             </h1>
-            <p class="text-xl text-gray-600 max-w-3xl leading-relaxed font-medium mb-10">
-                這是一份不妥協的技術指南。我們將徹底解析 <code class="bg-gray-200 px-1.5 py-0.5 rounded text-sm font-mono text-[#1A1A1A]">queries.zip</code> 專案中，如何撰寫堅不可摧的 Hooks 來阻擋 Claude 讀取機密檔案。拋棄死板的教學，請直接在下方的模擬器中驗證你的邏輯。
+            <p class="text-lg text-gray-400 font-light leading-relaxed">
+                放棄難懂的 JSON 封包與抽象的節點圖。我們直接用「情境對比」，讓你一秒看懂 SDK 到底在幹嘛、它跟傳統 API 差在哪，以及為什麼程式會自己「知錯能改」。
             </p>
-            
-            <!-- Context Box -->
-            <div class="bg-white card-shadow rounded-2xl p-6 border border-gray-100 flex flex-col md:flex-row gap-6 items-center">
-                <div class="w-16 h-16 bg-red-50 rounded-2xl flex items-center justify-center flex-shrink-0 border border-red-100">
-                    <svg class="w-8 h-8 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path></svg>
-                </div>
-                <div>
-                    <h3 class="font-bold text-[#1A1A1A] text-lg mb-1">防禦標靶：機密檔案 .env</h3>
-                    <p class="text-gray-600 text-sm">目標環境中存在 <code class="font-mono text-red-500">SECRET_API_KEY="SUPER SECRET"</code>。我們的唯一任務，就是實作完美無瑕的 Hook 邏輯，在 Claude 觸碰它之前將其攔截。</p>
-                </div>
-            </div>
-        </header>
+        </div>
+    </header>
 
-        <!-- Step 1: Pre vs Post Lifecycle -->
-        <section class="space-y-8">
-            <div class="flex items-start gap-4">
-                <div class="w-12 h-12 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">1</div>
-                <div>
-                    <h2 class="text-3xl font-bold mb-2">時機決定命運：Pre vs Post</h2>
-                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed">
-                        防護檔案的鐵則：<strong>必須在操作發生前攔截。</strong> 許多開發者誤用 <code>PostToolUse</code> 紀錄日誌並回傳錯誤碼，卻不知道此時檔案早已被 Claude 讀取完畢。
-                    </p>
-                </div>
-            </div>
+    <main class="max-w-4xl mx-auto px-6 mt-16 space-y-24">
 
-            <div class="w-full overflow-x-auto no-scrollbar ml-0 md:ml-16">
-                <div class="min-w-[800px] bg-white rounded-3xl card-shadow border border-gray-100 p-2 flex gap-2">
-                    
-                    <!-- Controls -->
-                    <div class="w-1/3 p-6 flex flex-col gap-3">
-                        <div class="text-sm font-bold text-gray-400 uppercase tracking-widest mb-2">Hook Lifecycle</div>
-                        <button onclick="runStep1('pre')" id="s1-btn-pre" class="w-full text-left px-5 py-4 bg-[#1A1A1A] text-white rounded-xl font-bold shadow-md ring-2 ring-[#C88A64] ring-offset-2 transition-all">
-                            PreToolUse
-                            <span class="block text-xs font-normal text-gray-400 mt-1">執行前觸發 (可阻擋)</span>
-                        </button>
-                        <button onclick="runStep1('post')" id="s1-btn-post" class="w-full text-left px-5 py-4 bg-gray-50 text-gray-600 hover:bg-gray-100 rounded-xl font-bold border border-gray-200 transition-all">
-                            PostToolUse
-                            <span class="block text-xs font-normal text-gray-400 mt-1">執行後觸發 (僅能報錯)</span>
-                        </button>
-                        <div class="mt-auto pt-6 border-t border-gray-100">
-                            <button onclick="playStep1()" class="w-full bg-[#C88A64] hover:bg-opacity-90 text-white py-3 rounded-xl font-bold shadow transition-transform active:scale-95 flex items-center justify-center gap-2">
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                                模擬 Claude 讀取檔案
-                            </button>
-                        </div>
+        <!-- Module 1: 依賴陷阱 (維持極簡對比) -->
+        <section>
+            <div class="flex items-center gap-3 mb-6">
+                <div
+                    class="w-10 h-10 bg-themeDark text-themeAccent rounded-lg flex items-center justify-center font-mono font-bold text-lg">
+                    1</div>
+                <h2 class="text-2xl font-bold">第一關：千萬別抄影片的程式碼</h2>
+            </div>
+            <p class="text-gray-700 mb-6">
+                官方教學影片裡示範的套件名稱已經過期。如果你照抄，程式根本跑不起來。請認明下方的正確版本：
+            </p>
+            <div class="w-full overflow-x-auto no-scrollbar">
+                <div
+                    class="min-w-[700px] grid grid-cols-2 rounded-xl overflow-hidden border border-gray-300 shadow-sm bg-white">
+                    <div class="p-6 bg-[#2a1c1c] border-r border-gray-300">
+                        <div class="text-red-400 font-bold text-sm mb-3">❌ 影片舊版寫法 (會報錯)</div>
+                        <code
+                            class="block text-sm font-mono text-gray-400 line-through decoration-red-500 mb-2">npm install @anthropic-ai/claude-code</code>
+                        <code
+                            class="block text-sm font-mono text-gray-400 opacity-50">import { query } from "@anthropic-ai/claude-code";</code>
                     </div>
-
-                    <!-- Animation Canvas -->
-                    <div class="w-2/3 bg-[#F8F8F5] rounded-2xl border border-gray-200 relative overflow-hidden flex flex-col items-center py-10 px-8">
-                        
-                        <div class="w-full flex justify-between items-center z-10 px-8">
-                            <div class="text-center">
-                                <div class="w-16 h-16 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center shadow-lg mx-auto mb-3">
-                                    <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
-                                </div>
-                                <span class="font-mono font-bold text-sm">Claude Engine</span>
-                            </div>
-
-                            <!-- Dynamic Hook Wall -->
-                            <div id="s1-hook-wall" class="absolute left-1/2 top-1/2 -translate-y-1/2 -translate-x-1/2 flex flex-col items-center transition-all duration-700 ease-in-out z-20">
-                                <div id="s1-shield" class="w-20 h-24 bg-[#C88A64] rounded-xl flex items-center justify-center shadow-2xl border-4 border-white">
-                                    <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
-                                </div>
-                                <div class="bg-[#1A1A1A] text-white text-xs font-mono px-3 py-1 rounded-full mt-2 font-bold shadow-md" id="s1-hook-label">PreToolUse</div>
-                            </div>
-
-                            <div class="text-center relative">
-                                <div id="s1-target-file" class="w-16 h-16 bg-white border-2 border-gray-300 text-gray-500 rounded-2xl flex items-center justify-center shadow-sm mx-auto mb-3 transition-colors duration-300">
-                                    <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
-                                </div>
-                                <span class="font-mono font-bold text-sm">.env</span>
-                            </div>
-                        </div>
-
-                        <!-- Data Track -->
-                        <div class="absolute top-1/2 left-24 right-24 h-[2px] bg-gray-200 -translate-y-1/2 z-0"></div>
-                        
-                        <!-- Moving Packet -->
-                        <div id="s1-packet" class="absolute top-1/2 left-24 w-4 h-4 rounded-full bg-[#1A1A1A] -translate-y-1/2 -ml-2 opacity-0 z-10 transition-all duration-[800ms] ease-in-out shadow-[0_0_10px_rgba(26,26,26,0.5)]"></div>
-
-                        <!-- Verdict Feedback -->
-                        <div id="s1-feedback" class="absolute bottom-6 left-1/2 -translate-x-1/2 bg-white px-6 py-3 rounded-xl shadow-xl border border-gray-100 text-sm font-bold opacity-0 transition-opacity flex items-center gap-2">
-                        </div>
-
+                    <div class="p-6 bg-themeDark">
+                        <div class="text-themeAccent font-bold text-sm mb-3">✅ 最新正確寫法 (請用這個)</div>
+                        <code
+                            class="block text-sm font-mono text-white mb-2">npm install <span class="text-themeAccent">@anthropic-ai/claude-agent-sdk</span></code>
+                        <code
+                            class="block text-sm font-mono text-gray-300">import { query } from <span class="text-themeAccent">"@anthropic-ai/claude-agent-sdk"</span>;</code>
                     </div>
                 </div>
             </div>
         </section>
 
-        <!-- Step 2: Determine Tools (Dynamic MCP) -->
-        <section class="space-y-8">
-            <div class="flex items-start gap-4">
-                <div class="w-12 h-12 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">2</div>
-                <div>
-                    <h2 class="text-3xl font-bold mb-2">鎖定目標工具：隱蔽的 Grep 與動態 MCP</h2>
-                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed">
-                        防禦網的第二步是定義要攔截的 <code>tool_name</code>。除了直覺的 <code>Read</code>，開發者極常漏掉 <strong><code>Grep</code></strong>（搜尋內容等同讀取內容）。另外，由於 MCP Servers 會動態注入工具，最佳實踐是直接透過終端機探測。
-                    </p>
-                </div>
+        <!-- Module 2: 串流軌跡 (白話文對比版) -->
+        <section>
+            <div class="flex items-center gap-3 mb-6">
+                <div
+                    class="w-10 h-10 bg-themeDark text-themeAccent rounded-lg flex items-center justify-center font-mono font-bold text-lg">
+                    2</div>
+                <h2 class="text-2xl font-bold">什麼是「串流思考軌跡」？</h2>
             </div>
 
-            <div class="w-full overflow-x-auto no-scrollbar ml-0 md:ml-16">
-                <div class="min-w-[900px] flex gap-6">
-                    
-                    <!-- Code/Table Hybrid -->
-                    <div class="w-[45%] bg-white rounded-3xl card-shadow border border-gray-100 overflow-hidden flex flex-col">
-                        <div class="bg-[#1A1A1A] px-5 py-4 text-white font-mono text-sm flex justify-between items-center">
-                            <span>Target Tools (Watchlist)</span>
-                            <span class="bg-red-500 bg-opacity-20 text-red-300 px-2 py-0.5 rounded text-xs">High Risk</span>
-                        </div>
-                        <div class="p-6 flex-1 bg-gray-50">
-                            <ul class="space-y-4 font-mono text-sm">
-                                <li class="bg-white border border-gray-200 p-4 rounded-xl shadow-sm flex justify-between items-start border-l-4 border-l-red-500">
-                                    <div>
-                                        <div class="font-bold text-red-600 mb-1">"Read"</div>
-                                        <div class="text-gray-500 text-xs font-sans">直接讀取指定檔案的所有內容。</div>
-                                    </div>
-                                    <svg class="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
-                                </li>
-                                <li class="bg-white border border-gray-200 p-4 rounded-xl shadow-sm flex justify-between items-start border-l-4 border-l-red-500">
-                                    <div>
-                                        <div class="font-bold text-red-600 mb-1">"Grep"</div>
-                                        <div class="text-gray-500 text-xs font-sans">搜尋檔案內容。<strong class="text-red-500">邊緣案例：</strong> 若 Claude 搜尋 <code>API_KEY</code>，一樣會把機密回傳給 LLM。</div>
-                                    </div>
-                                    <svg class="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
-                                </li>
-                                <li class="bg-white border border-gray-200 p-4 rounded-xl shadow-sm flex justify-between items-center opacity-60">
-                                    <div class="font-bold text-gray-700">"Bash", "Glob", "Edit"...</div>
-                                    <div class="text-gray-400 text-xs font-sans">(根據需求決定是否攔截)</div>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
+            <p class="text-gray-700 mb-6 leading-relaxed">
+                很多人不懂為什麼 SDK 要寫 <code>for await (const event of query())</code>。因為它不是一個「按下去等答案」的
+                API，而是一個<strong>「實況轉播台」</strong>。<br>
+                點擊下方按鈕，看看「傳統 API」和「Agent SDK」在處理同一個任務時，你看到的畫面有什麼不同：
+            </p>
 
-                    <!-- Terminal Emulator -->
-                    <div class="w-[55%] bg-[#1A1A1A] rounded-3xl card-shadow border border-gray-800 flex flex-col overflow-hidden">
-                        <div class="bg-black bg-opacity-40 px-4 py-3 flex items-center gap-2 border-b border-gray-800">
-                            <div class="w-3 h-3 rounded-full bg-red-500"></div>
-                            <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
-                            <div class="w-3 h-3 rounded-full bg-green-500"></div>
-                            <span class="ml-4 text-xs font-mono text-gray-500">探測動態工具清單</span>
-                        </div>
-                        <div class="p-6 font-mono text-sm text-gray-300 flex-1 overflow-y-auto term-scroll" id="s2-term">
-                            <div class="text-green-400 mb-2">➜ queries git:(dev) ✗ <span class="text-white">claude</span></div>
-                            <div class="mb-6"><span class="text-[#C88A64]">></span> <span class="text-gray-500 border-b border-gray-500 border-dotted cursor-pointer hover:text-white transition-colors" onclick="runS2Term()">點擊此處自動輸入探測指令</span><span class="border-r-2 border-white ml-0.5 caret-blink"></span></div>
-                        </div>
-                    </div>
+            <div class="w-full overflow-x-auto no-scrollbar">
+                <div
+                    class="min-w-[800px] bg-white border border-gray-300 rounded-xl shadow-lg overflow-hidden flex flex-col">
 
-                </div>
-            </div>
-        </section>
-
-        <!-- Step 3: Parse Standard In -->
-        <section class="space-y-8">
-            <div class="flex items-start gap-4">
-                <div class="w-12 h-12 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">3</div>
-                <div>
-                    <h2 class="text-3xl font-bold mb-2">解析 Standard In (JSON Payload Diff)</h2>
-                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed">
-                        Hook 觸發時，Claude 會將 JSON 資料注入到腳本的 <code>Standard In (stdin)</code>。防禦腳本最常犯的錯就是**沒有正確處理屬性差異**。比較下方 <code>Read</code> 與 <code>Grep</code> 的結構差異。
-                    </p>
-                </div>
-            </div>
-
-            <div class="w-full overflow-x-auto no-scrollbar ml-0 md:ml-16">
-                <div class="min-w-[900px] bg-[#1A1A1A] rounded-3xl card-shadow border border-gray-800 overflow-hidden flex flex-col">
-                    
-                    <!-- Diff Tabs -->
-                    <div class="flex bg-black bg-opacity-50 border-b border-gray-800">
-                        <button onclick="setDiff('read')" id="btn-diff-read" class="px-6 py-4 font-mono text-sm font-bold text-white border-b-2 border-[#C88A64] transition-colors">
-                            Read Payload (常規)
-                        </button>
-                        <button onclick="setDiff('grep')" id="btn-diff-grep" class="px-6 py-4 font-mono text-sm font-bold text-gray-500 border-b-2 border-transparent hover:text-gray-300 transition-colors">
-                            Grep Payload (邊緣案例)
+                    <div class="bg-gray-100 px-6 py-4 border-b border-gray-300 flex justify-between items-center">
+                        <span class="font-mono text-sm font-bold text-gray-700">任務：找出專案目錄裡有幾個 JS 檔案</span>
+                        <button onclick="runRaceDemo()" id="btn-race"
+                            class="bg-themeDark hover:bg-themeAccent text-white px-4 py-2 rounded-lg font-bold text-sm transition-colors shadow">
+                            開始執行比較
                         </button>
                     </div>
 
-                    <!-- Diff Content -->
-                    <div class="p-8 font-mono text-sm leading-relaxed relative min-h-[280px]">
-                        <!-- Common part -->
-                        <div class="text-gray-400">{</div>
-                        <div class="text-gray-400 pl-4">"session_id": "2d6a1e4d-6...",</div>
-                        <div class="text-gray-400 pl-4">"hook_event_name": "PreToolUse",</div>
-                        
-                        <!-- Changing part wrapper -->
-                        <div id="diff-content" class="transition-all duration-300">
-                            <!-- Injected by JS -->
+                    <div class="flex h-[320px] bg-white divide-x divide-gray-200">
+                        <!-- 左：傳統 API -->
+                        <div class="w-1/2 p-6 flex flex-col">
+                            <h3 class="text-sm font-bold text-gray-500 mb-4 uppercase tracking-widest text-center">傳統
+                                API (乾等模式)</h3>
+                            <div
+                                class="flex-1 bg-gray-50 rounded-lg p-4 font-mono text-sm border border-gray-200 flex flex-col justify-center items-center relative">
+                                <div id="api-loading" class="hidden text-gray-400 font-bold">送出請求，伺服器處理中<span
+                                        class="loading-dots"></span></div>
+                                <div id="api-result"
+                                    class="hidden mt-4 text-themeDark bg-white px-4 py-2 rounded border border-gray-300 shadow-sm w-full text-center fade-in-up">
+                                    [最終答案] 找到了！總共有 5 個 JS 檔案。
+                                </div>
+                            </div>
                         </div>
 
-                        <div class="text-gray-400">}</div>
-                        
-                        <!-- Note -->
-                        <div class="absolute bottom-6 right-8 bg-[#C88A64] bg-opacity-10 border border-[#C88A64] text-[#C88A64] px-4 py-3 rounded-xl text-xs max-w-sm flex gap-3 items-start">
-                            <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                            <p id="diff-note">你的解析器必須擷取 <code>file_path</code> 來檢查是否為敏感檔案。</p>
+                        <!-- 右：SDK Agent -->
+                        <div class="w-1/2 p-6 flex flex-col">
+                            <h3 class="text-sm font-bold text-themeAccent mb-4 uppercase tracking-widest text-center">
+                                Agent SDK (實況串流)</h3>
+                            <div id="sdk-stream"
+                                class="flex-1 bg-themeCode rounded-lg p-4 font-mono text-sm text-gray-300 overflow-y-auto space-y-3 relative">
+                                <div class="text-gray-500 italic text-center absolute inset-0 flex items-center justify-center pointer-events-none"
+                                    id="sdk-placeholder">等待執行...</div>
+                                <!-- 串流內容會動態插入這裡 -->
+                            </div>
                         </div>
                     </div>
 
                 </div>
             </div>
+            <p class="text-sm text-gray-500 mt-4 text-center">
+                💡 這就是 <code>for await</code> 的威力：你能「攔截」到它每一次決定使用工具 (tool_use) 的瞬間，用來實作 UI 進度條，而不是讓用戶看著畫面發呆。
+            </p>
         </section>
 
-        <!-- Step 4: Exit Codes & Logic Builder -->
-        <section class="space-y-8">
-            <div class="flex items-start gap-4">
-                <div class="w-12 h-12 bg-[#C88A64] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">4</div>
-                <div class="flex-1">
-                    <h2 class="text-3xl font-bold mb-2">決策與反饋：防禦腳本編譯與測試實驗室</h2>
-                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed mb-6">
-                        之前的設計確實違反直覺，因為它把「寫腳本」跟「執行測試」混在一起了！<br>
-                        好的開發者體驗應該是：<strong>先設定好你的防禦邏輯 (Script Builder)，再丟入不同的檔案來進行測試 (Test Lab)。</strong>
-                    </p>
-                    
-                    <div class="w-full overflow-x-auto no-scrollbar flex flex-col gap-6">
-                        
-                        <!-- Top: Script Builder -->
-                        <div class="min-w-[950px] bg-white rounded-3xl card-shadow border border-gray-200 flex overflow-hidden">
-                            <!-- Left: Configuration Panel -->
-                            <div class="w-[45%] bg-gray-50 border-r border-gray-200 flex flex-col">
-                                <div class="px-6 py-4 border-b border-gray-200 bg-white font-bold text-gray-800 flex items-center justify-between">
-                                    <span>1. 腳本邏輯設定 (Script Builder)</span>
-                                </div>
-                                <div class="p-6 flex-1 space-y-6">
-                                    
-                                    <div>
-                                        <label class="block text-sm font-bold text-gray-700 mb-2">A. 攔截條件 (If matches):</label>
-                                        <select id="s4-if-cond" onchange="updateScriptPreview()" class="w-full bg-white border-2 border-gray-200 rounded-xl px-4 py-3 text-sm font-mono focus:border-[#C88A64] outline-none">
-                                            <option value="env">*".env"* (僅攔截機密檔案)</option>
-                                            <option value="all">"*" (攔截所有檔案)</option>
-                                        </select>
-                                    </div>
+        <!-- Module 3: 沙箱與錯誤迴圈 (白話文情境版) -->
+        <section>
+            <div class="flex items-center gap-3 mb-6">
+                <div
+                    class="w-10 h-10 bg-themeDark text-themeAccent rounded-lg flex items-center justify-center font-mono font-bold text-lg">
+                    3</div>
+                <h2 class="text-2xl font-bold">「預設唯讀」與神奇的錯誤迴圈</h2>
+            </div>
 
-                                    <div>
-                                        <label class="block text-sm font-bold text-gray-700 mb-2">B. 條件成立時的動作 (Action):</label>
-                                        <div class="flex bg-white border-2 border-gray-200 rounded-xl overflow-hidden text-sm font-mono">
-                                            <button id="s4-btn-exit2" onclick="setIfExit(2)" class="flex-1 py-3 bg-red-50 text-red-700 font-bold border-r-2 border-gray-200 transition-colors">Exit 2 (Block)</button>
-                                            <button id="s4-btn-exit0" onclick="setIfExit(0)" class="flex-1 py-3 text-gray-500 hover:bg-gray-50 transition-colors">Exit 0 (Allow)</button>
-                                        </div>
-                                    </div>
+            <p class="text-gray-700 mb-6 leading-relaxed">
+                這是初學者最常跌倒的坑：SDK 為了安全，<strong>預設不准修改檔案</strong>。如果你在 Prompt 要求它改檔案，程式不會當機，而是會上演一段「被警衛攔下，然後乖乖道歉」的戲碼。<br>
+                觀察下方模擬器，看看「有給權限」和「沒給權限」時，底層系統與 AI 之間的對話是怎麼進行的。
+            </p>
 
-                                    <div id="s4-stderr-container">
-                                        <label class="block text-sm font-bold text-gray-700 mb-2">C. 拒絕理由 (Stderr feedback):</label>
-                                        <input type="text" id="s4-stderr" value="Access Denied: .env files are restricted." onkeyup="updateScriptPreview()" class="w-full bg-white border-2 border-gray-200 rounded-xl px-4 py-3 text-sm font-mono focus:border-[#C88A64] outline-none">
-                                    </div>
+            <div class="w-full overflow-x-auto no-scrollbar">
+                <div
+                    class="min-w-[800px] border border-gray-300 rounded-xl overflow-hidden shadow-lg bg-white flex flex-col">
 
-                                    <div class="pt-4 border-t border-gray-200">
-                                        <label class="block text-sm font-bold text-gray-700 mb-2">D. 預設行為 (Default Action):</label>
-                                        <select id="s4-def-exit" onchange="updateScriptPreview()" class="w-full bg-white border-2 border-gray-200 rounded-xl px-4 py-3 text-sm font-mono focus:border-[#C88A64] outline-none">
-                                            <option value="0">Exit 0 (預設放行其餘檔案)</option>
-                                            <option value="2">Exit 2 (預設全面封殺)</option>
-                                        </select>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Right: Live Code Preview -->
-                            <div class="w-[55%] flex flex-col bg-[#1A1A1A] text-gray-300 font-mono text-[13px]">
-                                <div class="px-5 py-3 border-b border-gray-800 flex justify-between bg-black bg-opacity-40">
-                                    <span class="text-gray-400">hook_script.sh (即時編譯)</span>
-                                    <span class="text-[#C88A64]">Bash</span>
-                                </div>
-                                <div class="p-6 flex-1 bg-[#1A1A1A] leading-relaxed relative">
-                                    <div class="text-gray-500 italic mb-4"># Extract path from stdin</div>
-                                    <div class="text-blue-400">TARGET_PATH<span class="text-white">=</span><span class="text-gray-400">$(cat - | jq -r '.tool_input.file_path')</span></div>
-                                    <br>
-                                    
-                                    <!-- Dynamic IF Block -->
-                                    <div class="relative">
-                                        <div id="live-if-strip" class="absolute -left-4 top-0 bottom-0 w-1 bg-[#C88A64] opacity-50 rounded-r"></div>
-                                        <div class="text-purple-400">if <span class="text-white">[[</span> <span class="text-gray-300">"$TARGET_PATH"</span> <span class="text-white">==</span> <span class="text-green-300" id="live-if-cond">*".env"*</span> <span class="text-white">]];</span> then</div>
-                                        <div id="live-stderr-block" class="pl-4 mt-1">
-                                            <span class="text-blue-300">echo</span> <span class="text-green-300">"<span id="live-stderr-text">Access Denied: .env files are restricted.</span>"</span> <span class="text-red-400">>&2</span>
-                                        </div>
-                                        <div class="pl-4 mt-1">
-                                            <span class="text-blue-300">exit</span> <span id="live-if-exit" class="text-red-400 font-bold">2</span>
-                                        </div>
-                                        <div class="text-purple-400">fi</div>
-                                    </div>
-
-                                    <br>
-                                    <div class="text-gray-500 italic"># Default behavior</div>
-                                    <div class="text-blue-300">exit <span id="live-def-exit" class="text-green-400 font-bold">0</span></div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Bottom: Test Lab -->
-                        <div class="min-w-[950px] bg-[#1A1A1A] rounded-3xl card-shadow border border-gray-800 overflow-hidden flex flex-col">
-                            <div class="bg-gray-900 px-6 py-4 border-b border-gray-800 flex items-center justify-between">
-                                <span class="font-bold text-white">2. 測試實驗室 (Test Lab)</span>
-                            </div>
-                            <div class="flex p-6 gap-6">
-                                <div class="w-1/3 flex flex-col gap-4">
-                                    <div class="text-sm font-mono text-gray-400 mb-2">請選擇模擬輸入檔案：</div>
-                                    <button onclick="runTest('danger')" class="w-full bg-red-900 bg-opacity-20 hover:bg-opacity-40 border border-red-800 text-red-300 font-bold py-4 rounded-xl transition-all text-sm font-mono flex flex-col items-center gap-1">
-                                        <span>[ 測試讀取 .env ]</span>
-                                        <span class="text-[10px] font-normal text-red-400/60">應觸發攔截規則</span>
-                                    </button>
-                                    <button onclick="runTest('safe')" class="w-full bg-green-900 bg-opacity-20 hover:bg-opacity-40 border border-green-800 text-green-300 font-bold py-4 rounded-xl transition-all text-sm font-mono flex flex-col items-center gap-1">
-                                        <span>[ 測試讀取 package.json ]</span>
-                                        <span class="text-[10px] font-normal text-green-400/60">應觸發預設規則</span>
-                                    </button>
-                                </div>
-                                <div class="w-2/3 bg-black rounded-xl border border-gray-800 flex flex-col">
-                                    <div class="px-4 py-2 text-[11px] text-gray-500 border-b border-gray-800 uppercase tracking-widest">Claude Context Engine Output</div>
-                                    <div id="s4-term-out" class="p-4 overflow-y-auto term-scroll flex-1 text-xs font-mono space-y-1.5 h-48">
-                                        <div class="text-gray-600">等待測試觸發...</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
+                    <div class="bg-gray-100 px-6 py-4 border-b border-gray-300 flex justify-center gap-4">
+                        <button onclick="runGotchaDemo('fail')" id="btn-gotcha-fail"
+                            class="bg-[#2A1A1A] text-red-400 px-4 py-2 rounded-lg font-mono text-sm border border-red-900/30 hover:bg-[#3A1A1A] transition-colors">
+                            模擬 1：未設定 Edit 權限 (觀察出錯)
+                        </button>
+                        <button onclick="runGotchaDemo('success')" id="btn-gotcha-succ"
+                            class="bg-themeAccent/10 text-themeAccent px-4 py-2 rounded-lg font-mono text-sm border border-themeAccent/30 hover:bg-themeAccent/20 transition-colors">
+                            模擬 2：加入 allowedTools: ["Edit"]
+                        </button>
                     </div>
+
+                    <div class="flex flex-col p-6 h-[400px] bg-themeBg overflow-y-auto" id="chat-container">
+                        <div class="text-center text-gray-400 italic font-mono text-sm my-auto" id="chat-placeholder">
+                            請點擊上方按鈕開始模擬...
+                        </div>
+                        <!-- 對話泡泡會動態插入這裡 -->
+                    </div>
+
                 </div>
+            </div>
+            <div class="mt-4 p-4 bg-gray-100 rounded-lg text-sm text-gray-700 font-mono leading-relaxed">
+                <span class="font-bold text-themeDark">👨‍💻 程式碼解法：</span><br>
+                在呼叫時加上 <code
+                    class="bg-white px-1 text-themeAccent border border-gray-200">options: { allowedTools: ["Edit"] }</code>，或是修改專案底下的
+                <code class="bg-white px-1 border border-gray-200">.claude/settings.json</code>，就能發給它通行證。
             </div>
         </section>
 
     </main>
 
+    <footer class="w-full bg-themeDark py-8 mt-20 text-center text-gray-500 font-mono text-sm">
+        Claude Agent SDK • Plain Language Visual Guide
+    </footer>
+
     <script>
-        // --- Step 1: Pre vs Post Animation ---
-        let s1Type = 'pre';
-        function runStep1(type) {
-            s1Type = type;
-            const btnPre = document.getElementById('s1-btn-pre');
-            const btnPost = document.getElementById('s1-btn-post');
-            const hookWall = document.getElementById('s1-hook-wall');
-            const shield = document.getElementById('s1-shield');
-            const label = document.getElementById('s1-hook-label');
-            const targetFile = document.getElementById('s1-target-file');
+        // --- Module 2: 傳統 API vs SDK 串流競速 ---
+        let isRaceRunning = false;
+        async function runRaceDemo() {
+            if (isRaceRunning) return;
+            isRaceRunning = true;
 
-            // Reset UI
-            targetFile.className = 'w-16 h-16 bg-white border-2 border-gray-300 text-gray-500 rounded-2xl flex items-center justify-center shadow-sm mx-auto mb-3 transition-colors duration-300';
-            document.getElementById('s1-packet').style.opacity = '0';
-            document.getElementById('s1-packet').style.left = '24px';
-            const feedback = document.getElementById('s1-feedback');
-            feedback.style.opacity = '0';
-            feedback.className = 'absolute bottom-6 left-1/2 -translate-x-1/2 bg-white px-6 py-3 rounded-xl shadow-xl border border-gray-100 text-sm font-bold opacity-0 transition-opacity flex items-center gap-2';
+            const btn = document.getElementById('btn-race');
+            const apiLoad = document.getElementById('api-loading');
+            const apiRes = document.getElementById('api-result');
+            const sdkStream = document.getElementById('sdk-stream');
+            const placeholder = document.getElementById('sdk-placeholder');
 
+            btn.classList.add('opacity-50', 'cursor-not-allowed');
+            apiLoad.classList.remove('hidden');
+            apiRes.classList.add('hidden');
+            sdkStream.innerHTML = '';
+            if (placeholder) placeholder.style.display = 'none';
 
-            if(type === 'pre') {
-                btnPre.className = 'w-full text-left px-5 py-4 bg-[#1A1A1A] text-white rounded-xl font-bold shadow-md ring-2 ring-[#C88A64] ring-offset-2 transition-all';
-                btnPost.className = 'w-full text-left px-5 py-4 bg-gray-50 text-gray-600 hover:bg-gray-100 rounded-xl font-bold border border-gray-200 transition-all';
-                
-                // Position wall in the middle
-                hookWall.style.left = '50%';
-                shield.className = 'w-20 h-24 bg-[#C88A64] rounded-xl flex items-center justify-center shadow-2xl border-4 border-white transition-colors duration-300';
-                label.innerText = 'PreToolUse';
-            } else {
-                btnPost.className = 'w-full text-left px-5 py-4 bg-[#1A1A1A] text-white rounded-xl font-bold shadow-md ring-2 ring-[#C88A64] ring-offset-2 transition-all';
-                btnPre.className = 'w-full text-left px-5 py-4 bg-gray-50 text-gray-600 hover:bg-gray-100 rounded-xl font-bold border border-gray-200 transition-all';
-                
-                // Position wall AFTER the file
-                hookWall.style.left = '85%';
-                shield.className = 'w-20 h-24 bg-gray-400 rounded-xl flex items-center justify-center shadow-2xl border-4 border-white transition-colors duration-300';
-                label.innerText = 'PostToolUse';
-            }
-        }
+            // 準備 SDK 串流的每一句話
+            const sdkSteps = [
+                { type: 'message_start', text: '收到任務，我開始思考了...' },
+                { type: 'tool_use', text: '決定使用工具：打開目錄閱讀器 (read_dir)' },
+                { type: 'tool_result', text: '系統回報：目錄讀取完畢，檔案清單已獲取' },
+                { type: 'message', text: '整理資料中，準備回覆...' },
+                { type: 'final', text: '[最終答案] 找到了！總共有 5 個 JS 檔案。' }
+            ];
 
-        function playStep1() {
-            const packet = document.getElementById('s1-packet');
-            const targetFile = document.getElementById('s1-target-file');
-            const feedback = document.getElementById('s1-feedback');
-            const shield = document.getElementById('s1-shield');
-            
-            // Reset
-            packet.style.transition = 'none';
-            packet.style.left = '10%';
-            packet.style.opacity = '1';
-            feedback.style.opacity = '0';
-            targetFile.className = 'w-16 h-16 bg-white border-2 border-gray-300 text-gray-500 rounded-2xl flex items-center justify-center shadow-sm mx-auto mb-3 transition-colors duration-300';
+            // 模擬 SDK 一步步吐出資訊
+            for (let i = 0; i < sdkSteps.length; i++) {
+                await new Promise(r => setTimeout(r, 1000));
+                const div = document.createElement('div');
+                div.className = 'fade-in-up border-l-2 border-themeAccent pl-3 py-1';
 
-            // Trigger reflow
-            void packet.offsetWidth;
-            packet.style.transition = 'all 800ms ease-in-out';
-
-            if(s1Type === 'pre') {
-                packet.style.left = '45%'; // hits the wall
-                setTimeout(() => {
-                    shield.classList.replace('bg-[#C88A64]', 'bg-red-500');
-                    setTimeout(() => shield.classList.replace('bg-red-500', 'bg-[#C88A64]'), 500);
-                    
-                    feedback.innerHTML = '<span class="w-3 h-3 rounded-full bg-green-500"></span><span class="text-green-600">成功在讀取前攔截操作！檔案安全。</span>';
-                    feedback.style.opacity = '1';
-                    packet.style.opacity = '0';
-                }, 800);
-            } else {
-                packet.style.left = '100%'; // passes through
-                setTimeout(() => {
-                    targetFile.classList.replace('border-gray-300', 'border-red-500');
-                    targetFile.classList.replace('text-gray-500', 'text-red-500');
-                    targetFile.classList.add('bg-red-50');
-                }, 500); // changes color as packet passes
-
-                setTimeout(() => {
-                    shield.classList.replace('bg-gray-400', 'bg-red-500');
-                    setTimeout(() => shield.classList.replace('bg-red-500', 'bg-gray-400'), 500);
-
-                    feedback.innerHTML = '<span class="w-3 h-3 rounded-full bg-red-500"></span><span class="text-red-600">嚴重：檔案已被讀取！PostToolUse 攔截無效。</span>';
-                    feedback.style.opacity = '1';
-                    packet.style.opacity = '0';
-                }, 800);
-            }
-        }
-        runStep1('pre'); // Init
-
-
-        // --- Step 2: Terminal Typing ---
-        let s2IsTyping = false;
-        async function runS2Term() {
-            if(s2IsTyping) return;
-            s2IsTyping = true;
-            const term = document.getElementById('s2-term');
-            term.innerHTML = '<div class="text-green-400 mb-2">➜ queries git:(dev) ✗ <span class="text-white">claude</span></div>';
-            
-            const promptLine = document.createElement('div');
-            promptLine.className = 'mb-4 text-white';
-            promptLine.innerHTML = '<span class="text-[#C88A64]">></span> <span id="s2-type-target"></span><span class="border-r-2 border-white ml-0.5 caret-blink"></span>';
-            term.appendChild(promptLine);
-
-            const target = document.getElementById('s2-type-target');
-            const msg = "List out the names of all the tools you have access to, bullet point list.";
-            for(let i=0; i<msg.length; i++){
-                target.innerHTML += msg[i];
-                await new Promise(r => setTimeout(r, 20)); // typing speed
-            }
-
-            const thinkingLine = document.createElement('div');
-            thinkingLine.className = 'text-gray-500 italic mb-4 mt-2';
-            thinkingLine.innerText = '* Imagining...';
-            term.appendChild(thinkingLine);
-            await new Promise(r => setTimeout(r, 600));
-            thinkingLine.remove();
-
-            const output = document.createElement('div');
-            output.className = 'text-gray-300 fade-in space-y-2 pb-6';
-            output.innerHTML = `
-                <p>Here are the tools I have access to:</p>
-                <ul class="list-disc pl-5 font-mono">
-                    <li>Bash</li>
-                    <li class="bg-red-900 bg-opacity-30 text-red-200 inline-block px-1 rounded my-1 font-bold">Grep  <span class="text-xs font-normal text-red-400 ml-2">&lt;- ⚠️ Danger: File Access</span></li>
-                    <br>
-                    <li>Edit</li>
-                    <li class="bg-[#C88A64] bg-opacity-20 text-[#C88A64] inline-block px-1 rounded my-1 font-bold">Read  <span class="text-xs font-normal text-[#C88A64] ml-2">&lt;- 🎯 Target: File Access</span></li>
-                    <br>
-                    <li>Write</li>
-                    <li class="text-purple-400">MCP_Server_GitSearch</li>
-                    <li class="text-purple-400">MCP_Server_DBQuery</li>
-                </ul>
-                <p class="text-gray-500 text-xs mt-4 border-t border-gray-800 pt-2">/* 工具清單是動態的，依賴你掛載的 MCP Servers */</p>
-            `;
-            term.appendChild(output);
-            term.scrollTop = term.scrollHeight;
-            s2IsTyping = false;
-        }
-
-        // --- Step 3: JSON Diff ---
-        const diffPayloads = {
-            read: `
-<div class="text-[#C88A64] pl-4 font-bold">"tool_name": <span class="text-yellow-300">"Read"</span>,</div>
-<div class="text-[#C88A64] pl-4 font-bold">"tool_input": {</div>
-<div class="pl-8 bg-[#1A1A1A] border-l-2 border-[#C88A64] py-1 my-1 flex items-center">
-    <span class="text-blue-300">"file_path"</span><span class="text-gray-400">: </span><span class="text-green-300">"/code/queries/.env"</span>
-</div>
-<div class="text-[#C88A64] pl-4 font-bold">}</div>`,
-            grep: `
-<div class="text-[#C88A64] pl-4 font-bold">"tool_name": <span class="text-yellow-300">"Grep"</span>,</div>
-<div class="text-[#C88A64] pl-4 font-bold">"tool_input": {</div>
-<div class="pl-8 py-1"><span class="text-blue-300">"pattern"</span><span class="text-gray-400">: </span><span class="text-green-300">"SECRET"</span>,</div>
-<div class="pl-8 bg-[#1A1A1A] border-l-2 border-red-500 py-1 my-1 flex items-center">
-    <span class="text-blue-300">"target_path"</span><span class="text-gray-400">: </span><span class="text-green-300">"/code/queries/.env"</span>
-</div>
-<div class="text-[#C88A64] pl-4 font-bold">}</div>`
-        };
-
-        function setDiff(type) {
-            const btnR = document.getElementById('btn-diff-read');
-            const btnG = document.getElementById('btn-diff-grep');
-            const content = document.getElementById('diff-content');
-            const note = document.getElementById('diff-note');
-
-            content.classList.remove('fade-in');
-            void content.offsetWidth; // trigger reflow
-
-            if(type === 'read') {
-                btnR.className = 'px-6 py-4 font-mono text-sm font-bold text-white border-b-2 border-[#C88A64] transition-colors';
-                btnG.className = 'px-6 py-4 font-mono text-sm font-bold text-gray-500 border-b-2 border-transparent hover:text-gray-300 transition-colors';
-                note.innerHTML = '解析器必須擷取 <code>file_path</code> 來檢查是否為敏感檔案。';
-            } else {
-                btnG.className = 'px-6 py-4 font-mono text-sm font-bold text-white border-b-2 border-red-500 transition-colors';
-                btnR.className = 'px-6 py-4 font-mono text-sm font-bold text-gray-500 border-b-2 border-transparent hover:text-gray-300 transition-colors';
-                note.innerHTML = '<strong>陷阱！</strong> 在 Grep 工具中，路徑屬性變成了 <code>target_path</code>，而非 <code>file_path</code>。腳本必須相容處理。';
-            }
-
-            content.innerHTML = diffPayloads[type];
-            content.classList.add('fade-in');
-        }
-        setDiff('read'); // Init
-
-        // --- Step 4: Logic Builder & Execution ---
-        let currentIfExit = 2;
-        
-        function setIfExit(code) {
-            currentIfExit = code;
-            const btn2 = document.getElementById('s4-btn-exit2');
-            const btn0 = document.getElementById('s4-btn-exit0');
-            const stderrContainer = document.getElementById('s4-stderr-container');
-
-            if(code === 2) {
-                btn2.className = 'flex-1 py-3 bg-red-50 text-red-700 font-bold border-r-2 border-gray-200 transition-colors';
-                btn0.className = 'flex-1 py-3 text-gray-500 hover:bg-gray-50 transition-colors';
-                stderrContainer.style.opacity = '1';
-                stderrContainer.style.pointerEvents = 'auto';
-            } else {
-                btn0.className = 'flex-1 py-3 bg-gray-200 text-gray-800 font-bold transition-colors';
-                btn2.className = 'flex-1 py-3 text-gray-500 hover:bg-gray-50 border-r-2 border-gray-200 transition-colors';
-                stderrContainer.style.opacity = '0.4';
-                stderrContainer.style.pointerEvents = 'none';
-            }
-            updateScriptPreview();
-        }
-
-        function updateScriptPreview() {
-            const ifCond = document.getElementById('s4-if-cond').value;
-            const stderrVal = document.getElementById('s4-stderr').value;
-            const defExit = document.getElementById('s4-def-exit').value;
-
-            // Cond
-            document.getElementById('live-if-cond').innerText = ifCond === 'env' ? '*".env"*' : '"*"';
-            
-            // Exit in IF
-            const liveIfExit = document.getElementById('live-if-exit');
-            const liveStderrBlock = document.getElementById('live-stderr-block');
-            const liveIfStrip = document.getElementById('live-if-strip');
-
-            document.getElementById('live-stderr-text').innerText = stderrVal;
-
-            if (currentIfExit === 2) {
-                liveIfExit.innerText = '2';
-                liveIfExit.className = 'text-red-400 font-bold';
-                liveStderrBlock.style.opacity = '1';
-                liveIfStrip.className = 'absolute -left-4 top-0 bottom-0 w-1 bg-[#C88A64] opacity-50 rounded-r';
-            } else {
-                liveIfExit.innerText = '0';
-                liveIfExit.className = 'text-green-400 font-bold';
-                liveStderrBlock.style.opacity = '0.3';
-                liveIfStrip.className = 'absolute -left-4 top-0 bottom-0 w-1 bg-yellow-500 opacity-50 rounded-r';
-            }
-
-            // Default Exit
-            const liveDefExit = document.getElementById('live-def-exit');
-            liveDefExit.innerText = defExit;
-            liveDefExit.className = defExit === '0' ? 'text-green-400 font-bold' : 'text-red-400 font-bold';
-        }
-
-        function runTest(testType) {
-            const ifCond = document.getElementById('s4-if-cond').value;
-            const defExit = document.getElementById('s4-def-exit').value;
-            const stderrVal = document.getElementById('s4-stderr').value;
-            
-            const targetPath = testType === 'danger' ? '/code/queries/.env' : '/code/queries/package.json';
-            const term = document.getElementById('s4-term-out');
-            
-            term.innerHTML = '';
-            const log = (html, delay) => {
-                setTimeout(() => {
-                    const el = document.createElement('div');
-                    el.innerHTML = html;
-                    el.className = 'fade-in';
-                    term.appendChild(el);
-                    term.scrollTop = term.scrollHeight;
-                }, delay);
-            }
-
-            log('<span class="text-blue-400">></span> 注入輸入：<code>TARGET_PATH="' + targetPath + '"</code>', 100);
-            log('<span class="text-gray-500">></span> 執行腳本檢測...', 400);
-
-            let isMatch = false;
-            if (ifCond === 'all') {
-                isMatch = true;
-            } else if (ifCond === 'env' && testType === 'danger') {
-                isMatch = true;
-            }
-
-            if (isMatch) {
-                log('<span class="text-purple-400">> 條件成立，進入 if 區塊。</span>', 800);
-                
-                if (currentIfExit === 2) {
-                    log('<span class="text-red-400">> 觸發 exit 2 (中斷)</span>', 1200);
-                    log('<div class="mt-2 bg-red-900/30 border border-red-800 p-2 rounded text-red-200 font-bold">[TOOL BLOCKED] Claude 操作已被成功阻擋！</div>', 1600);
-                    log('<div class="mt-1 text-[#C88A64]">Claude 收到回饋: <span class="text-gray-300">"' + stderrVal + '"</span></div>', 1800);
+                if (sdkSteps[i].type === 'final') {
+                    div.innerHTML = `<span class="text-white font-bold block">${sdkSteps[i].text}</span>`;
                 } else {
-                    log('<span class="text-green-400">> 觸發 exit 0 (放行)</span>', 1200);
-                    log('<div class="mt-2 bg-yellow-900/30 border border-yellow-800 p-2 rounded text-yellow-200 font-bold">⚠️ [邏輯漏洞] 你攔截了檔案卻設定放行！</div>', 1600);
-                    log('<div class="mt-1 text-green-400 font-bold">[ALL IS WELL] Claude 成功讀取檔案。 (可能導致機密外洩)</div>', 1800);
+                    div.innerHTML = `
+                        <div class="text-[10px] text-themeAccent uppercase tracking-wider mb-0.5">${sdkSteps[i].type}</div>
+                        <div class="text-gray-300">${sdkSteps[i].text}</div>
+                    `;
                 }
-            } else {
-                log('<span class="text-gray-500">> 條件不成立，跳過 if 區塊。</span>', 800);
-                
-                if (defExit === '0') {
-                    log('<span class="text-green-400">> 腳本結束，觸發預設 exit 0</span>', 1200);
-                    log('<div class="mt-2 bg-green-900/20 border border-green-800 p-2 rounded text-green-400 font-bold">[ALL IS WELL] 正常檔案已被放行，操作繼續。</div>', 1600);
-                } else {
-                    log('<span class="text-red-400">> 腳本結束，觸發預設 exit 2</span>', 1200);
-                    log('<div class="mt-2 bg-red-900/30 border border-red-800 p-2 rounded text-red-200 font-bold">[TOOL BLOCKED] 檔案被預設防禦規則阻擋。</div>', 1600);
-                }
+                sdkStream.appendChild(div);
+                sdkStream.scrollTop = sdkStream.scrollHeight;
             }
+
+            // 此刻，傳統 API 才終於醒來給出答案
+            apiLoad.classList.add('hidden');
+            apiRes.classList.remove('hidden');
+
+            btn.classList.remove('opacity-50', 'cursor-not-allowed');
+            isRaceRunning = false;
+        }
+
+        // --- Module 3: 沙箱錯誤迴圈 (對話模擬) ---
+        let isGotchaRunning = false;
+        async function runGotchaDemo(mode) {
+            if (isGotchaRunning) return;
+            isGotchaRunning = true;
+
+            const chat = document.getElementById('chat-container');
+            chat.innerHTML = '';
+
+            const addBubble = (role, text, isError = false) => {
+                const div = document.createElement('div');
+                div.className = `fade-in-up flex w-full mb-4 ${role === 'ai' ? 'justify-start' : 'justify-end'}`;
+
+                let innerHTML = '';
+                if (role === 'ai') {
+                    // AI (Claude) 的泡泡
+                    innerHTML = `
+                        <div class="max-w-[70%]">
+                            <div class="text-[10px] text-gray-500 font-mono mb-1 ml-1">Claude 模型</div>
+                            <div class="bg-white border border-gray-300 text-gray-800 p-3 rounded-2xl rounded-tl-none shadow-sm text-sm">
+                                ${text}
+                            </div>
+                        </div>
+                    `;
+                } else {
+                    // System (SDK Guard) 的泡泡
+                    const bgColor = isError ? 'bg-red-50 border-red-200 text-red-700' : 'bg-green-50 border-green-200 text-green-700';
+                    const titleColor = isError ? 'text-red-500' : 'text-green-600';
+                    innerHTML = `
+                        <div class="max-w-[70%]">
+                            <div class="text-[10px] ${titleColor} font-mono mb-1 mr-1 text-right">SDK 系統防護網 (Sandbox Guard)</div>
+                            <div class="${bgColor} border p-3 rounded-2xl rounded-tr-none shadow-sm text-sm">
+                                ${text}
+                            </div>
+                        </div>
+                    `;
+                }
+                div.innerHTML = innerHTML;
+                chat.appendChild(div);
+                chat.scrollTop = chat.scrollHeight;
+            };
+
+            // 劇情開始
+            addBubble('ai', '你要求我編輯 package.json。好的，我發出工具請求：<code>edit_file("package.json")</code>');
+            await new Promise(r => setTimeout(r, 1200));
+
+            if (mode === 'fail') {
+                // 失敗情境 (攔截)
+                addBubble('system', '⛔ <strong>攔截！</strong>你沒有被授權使用 Edit 工具。我退回一個錯誤 JSON：<br><code>{"is_error": true, "content": "Permission denied"}</code>', true);
+                await new Promise(r => setTimeout(r, 1500));
+
+                addBubble('ai', '收到錯誤回報。原來我沒權限改檔案，那我改口道歉好了。');
+                await new Promise(r => setTimeout(r, 1000));
+
+                addBubble('ai', '「非常抱歉，我目前的設定檔不允許我編輯檔案，請幫我加上權限。」');
+            } else {
+                // 成功情境 (放行)
+                addBubble('system', '✅ <strong>放行！</strong>我檢查到 <code>allowedTools</code> 裡面有 "Edit"。檔案寫入成功。回傳：<br><code>{"is_error": false, "content": "Success"}</code>', false);
+                await new Promise(r => setTimeout(r, 1500));
+
+                addBubble('ai', '收到成功回報。任務完成了，我來回覆用戶。');
+                await new Promise(r => setTimeout(r, 1000));
+
+                addBubble('ai', '「我已經成功為您的 package.json 更新內容了！」');
+            }
+
+            isGotchaRunning = false;
         }
     </script>
 </body>
+
 </html>

--- a/public/2026-plan/section3/312002-defining-hooks.html
+++ b/public/2026-plan/section3/312002-defining-hooks.html
@@ -1,0 +1,682 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code Hooks | 終極實戰大師班</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --bg-base: #F8F8F5;
+            --brand-dark: #1A1A1A;
+            --brand-accent: #C88A64;
+            --brand-accent-hover: #b57a55;
+        }
+        body {
+            font-family: 'Noto Sans TC', sans-serif;
+            background-color: var(--bg-base);
+            color: var(--brand-dark);
+            -webkit-font-smoothing: antialiased;
+        }
+        .font-mono { font-family: 'JetBrains Mono', monospace; }
+        
+        /* 隱藏捲軸但保持可捲動 (手機端橫向滑動救星) */
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+        .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+
+        /* Term Scrollbar */
+        .term-scroll::-webkit-scrollbar { width: 6px; height: 6px; }
+        .term-scroll::-webkit-scrollbar-track { background: transparent; }
+        .term-scroll::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.2); border-radius: 3px; }
+        .term-scroll::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.4); }
+
+        /* 動畫 */
+        .fade-in { animation: fadeIn 0.4s cubic-bezier(0.4, 0, 0.2, 1) forwards; }
+        @keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+        
+        .pulse-soft { animation: pulseSoft 2s infinite; }
+        @keyframes pulseSoft { 
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+
+        /* 終端機閃爍游標 */
+        .caret-blink { animation: blink 1s step-end infinite; }
+        @keyframes blink { 50% { border-color: transparent; } }
+
+        /* 自訂選取反白顏色 */
+        ::selection { background: var(--brand-accent); color: white; }
+
+        /* 現代感卡片陰影 */
+        .card-shadow { box-shadow: 0 4px 24px -6px rgba(0, 0, 0, 0.08), 0 0 1px rgba(0,0,0,0.1); }
+    </style>
+</head>
+<body class="p-4 md:p-8 selection:bg-[#C88A64] selection:text-white">
+
+    <main class="max-w-6xl mx-auto space-y-24 pb-32">
+        
+        <!-- Hero Section -->
+        <header class="pt-16 pb-12 border-b border-gray-200 relative">
+            <div class="inline-flex items-center gap-2 bg-gray-100 border border-gray-200 text-gray-800 px-3 py-1 rounded-full text-xs font-bold tracking-widest uppercase mb-6">
+                <span class="w-2 h-2 rounded-full bg-[#C88A64] pulse-soft"></span>
+                Developer Advocate Deep Dive
+            </div>
+            <h1 class="text-5xl md:text-7xl font-black text-[#1A1A1A] leading-tight tracking-tight mb-6">
+                Claude Code Hooks<br>
+                <span class="text-[#C88A64]">底層機制與防禦實戰</span>
+            </h1>
+            <p class="text-xl text-gray-600 max-w-3xl leading-relaxed font-medium mb-10">
+                這是一份不妥協的技術指南。我們將徹底解析 <code class="bg-gray-200 px-1.5 py-0.5 rounded text-sm font-mono text-[#1A1A1A]">queries.zip</code> 專案中，如何撰寫堅不可摧的 Hooks 來阻擋 Claude 讀取機密檔案。拋棄死板的教學，請直接在下方的模擬器中驗證你的邏輯。
+            </p>
+            
+            <!-- Context Box -->
+            <div class="bg-white card-shadow rounded-2xl p-6 border border-gray-100 flex flex-col md:flex-row gap-6 items-center">
+                <div class="w-16 h-16 bg-red-50 rounded-2xl flex items-center justify-center flex-shrink-0 border border-red-100">
+                    <svg class="w-8 h-8 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path></svg>
+                </div>
+                <div>
+                    <h3 class="font-bold text-[#1A1A1A] text-lg mb-1">防禦標靶：機密檔案 .env</h3>
+                    <p class="text-gray-600 text-sm">目標環境中存在 <code class="font-mono text-red-500">SECRET_API_KEY="SUPER SECRET"</code>。我們的唯一任務，就是實作完美無瑕的 Hook 邏輯，在 Claude 觸碰它之前將其攔截。</p>
+                </div>
+            </div>
+        </header>
+
+        <!-- Step 1: Pre vs Post Lifecycle -->
+        <section class="space-y-8">
+            <div class="flex items-start gap-4">
+                <div class="w-12 h-12 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">1</div>
+                <div>
+                    <h2 class="text-3xl font-bold mb-2">時機決定命運：Pre vs Post</h2>
+                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed">
+                        防護檔案的鐵則：<strong>必須在操作發生前攔截。</strong> 許多開發者誤用 <code>PostToolUse</code> 紀錄日誌並回傳錯誤碼，卻不知道此時檔案早已被 Claude 讀取完畢。
+                    </p>
+                </div>
+            </div>
+
+            <div class="w-full overflow-x-auto no-scrollbar ml-0 md:ml-16">
+                <div class="min-w-[800px] bg-white rounded-3xl card-shadow border border-gray-100 p-2 flex gap-2">
+                    
+                    <!-- Controls -->
+                    <div class="w-1/3 p-6 flex flex-col gap-3">
+                        <div class="text-sm font-bold text-gray-400 uppercase tracking-widest mb-2">Hook Lifecycle</div>
+                        <button onclick="runStep1('pre')" id="s1-btn-pre" class="w-full text-left px-5 py-4 bg-[#1A1A1A] text-white rounded-xl font-bold shadow-md ring-2 ring-[#C88A64] ring-offset-2 transition-all">
+                            PreToolUse
+                            <span class="block text-xs font-normal text-gray-400 mt-1">執行前觸發 (可阻擋)</span>
+                        </button>
+                        <button onclick="runStep1('post')" id="s1-btn-post" class="w-full text-left px-5 py-4 bg-gray-50 text-gray-600 hover:bg-gray-100 rounded-xl font-bold border border-gray-200 transition-all">
+                            PostToolUse
+                            <span class="block text-xs font-normal text-gray-400 mt-1">執行後觸發 (僅能報錯)</span>
+                        </button>
+                        <div class="mt-auto pt-6 border-t border-gray-100">
+                            <button onclick="playStep1()" class="w-full bg-[#C88A64] hover:bg-opacity-90 text-white py-3 rounded-xl font-bold shadow transition-transform active:scale-95 flex items-center justify-center gap-2">
+                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                模擬 Claude 讀取檔案
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Animation Canvas -->
+                    <div class="w-2/3 bg-[#F8F8F5] rounded-2xl border border-gray-200 relative overflow-hidden flex flex-col items-center py-10 px-8">
+                        
+                        <div class="w-full flex justify-between items-center z-10 px-8">
+                            <div class="text-center">
+                                <div class="w-16 h-16 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center shadow-lg mx-auto mb-3">
+                                    <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                                </div>
+                                <span class="font-mono font-bold text-sm">Claude Engine</span>
+                            </div>
+
+                            <!-- Dynamic Hook Wall -->
+                            <div id="s1-hook-wall" class="absolute left-1/2 top-1/2 -translate-y-1/2 -translate-x-1/2 flex flex-col items-center transition-all duration-700 ease-in-out z-20">
+                                <div id="s1-shield" class="w-20 h-24 bg-[#C88A64] rounded-xl flex items-center justify-center shadow-2xl border-4 border-white">
+                                    <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
+                                </div>
+                                <div class="bg-[#1A1A1A] text-white text-xs font-mono px-3 py-1 rounded-full mt-2 font-bold shadow-md" id="s1-hook-label">PreToolUse</div>
+                            </div>
+
+                            <div class="text-center relative">
+                                <div id="s1-target-file" class="w-16 h-16 bg-white border-2 border-gray-300 text-gray-500 rounded-2xl flex items-center justify-center shadow-sm mx-auto mb-3 transition-colors duration-300">
+                                    <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                                </div>
+                                <span class="font-mono font-bold text-sm">.env</span>
+                            </div>
+                        </div>
+
+                        <!-- Data Track -->
+                        <div class="absolute top-1/2 left-24 right-24 h-[2px] bg-gray-200 -translate-y-1/2 z-0"></div>
+                        
+                        <!-- Moving Packet -->
+                        <div id="s1-packet" class="absolute top-1/2 left-24 w-4 h-4 rounded-full bg-[#1A1A1A] -translate-y-1/2 -ml-2 opacity-0 z-10 transition-all duration-[800ms] ease-in-out shadow-[0_0_10px_rgba(26,26,26,0.5)]"></div>
+
+                        <!-- Verdict Feedback -->
+                        <div id="s1-feedback" class="absolute bottom-6 left-1/2 -translate-x-1/2 bg-white px-6 py-3 rounded-xl shadow-xl border border-gray-100 text-sm font-bold opacity-0 transition-opacity flex items-center gap-2">
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Step 2: Determine Tools (Dynamic MCP) -->
+        <section class="space-y-8">
+            <div class="flex items-start gap-4">
+                <div class="w-12 h-12 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">2</div>
+                <div>
+                    <h2 class="text-3xl font-bold mb-2">鎖定目標工具：隱蔽的 Grep 與動態 MCP</h2>
+                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed">
+                        防禦網的第二步是定義要攔截的 <code>tool_name</code>。除了直覺的 <code>Read</code>，開發者極常漏掉 <strong><code>Grep</code></strong>（搜尋內容等同讀取內容）。另外，由於 MCP Servers 會動態注入工具，最佳實踐是直接透過終端機探測。
+                    </p>
+                </div>
+            </div>
+
+            <div class="w-full overflow-x-auto no-scrollbar ml-0 md:ml-16">
+                <div class="min-w-[900px] flex gap-6">
+                    
+                    <!-- Code/Table Hybrid -->
+                    <div class="w-[45%] bg-white rounded-3xl card-shadow border border-gray-100 overflow-hidden flex flex-col">
+                        <div class="bg-[#1A1A1A] px-5 py-4 text-white font-mono text-sm flex justify-between items-center">
+                            <span>Target Tools (Watchlist)</span>
+                            <span class="bg-red-500 bg-opacity-20 text-red-300 px-2 py-0.5 rounded text-xs">High Risk</span>
+                        </div>
+                        <div class="p-6 flex-1 bg-gray-50">
+                            <ul class="space-y-4 font-mono text-sm">
+                                <li class="bg-white border border-gray-200 p-4 rounded-xl shadow-sm flex justify-between items-start border-l-4 border-l-red-500">
+                                    <div>
+                                        <div class="font-bold text-red-600 mb-1">"Read"</div>
+                                        <div class="text-gray-500 text-xs font-sans">直接讀取指定檔案的所有內容。</div>
+                                    </div>
+                                    <svg class="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
+                                </li>
+                                <li class="bg-white border border-gray-200 p-4 rounded-xl shadow-sm flex justify-between items-start border-l-4 border-l-red-500">
+                                    <div>
+                                        <div class="font-bold text-red-600 mb-1">"Grep"</div>
+                                        <div class="text-gray-500 text-xs font-sans">搜尋檔案內容。<strong class="text-red-500">邊緣案例：</strong> 若 Claude 搜尋 <code>API_KEY</code>，一樣會把機密回傳給 LLM。</div>
+                                    </div>
+                                    <svg class="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
+                                </li>
+                                <li class="bg-white border border-gray-200 p-4 rounded-xl shadow-sm flex justify-between items-center opacity-60">
+                                    <div class="font-bold text-gray-700">"Bash", "Glob", "Edit"...</div>
+                                    <div class="text-gray-400 text-xs font-sans">(根據需求決定是否攔截)</div>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <!-- Terminal Emulator -->
+                    <div class="w-[55%] bg-[#1A1A1A] rounded-3xl card-shadow border border-gray-800 flex flex-col overflow-hidden">
+                        <div class="bg-black bg-opacity-40 px-4 py-3 flex items-center gap-2 border-b border-gray-800">
+                            <div class="w-3 h-3 rounded-full bg-red-500"></div>
+                            <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
+                            <div class="w-3 h-3 rounded-full bg-green-500"></div>
+                            <span class="ml-4 text-xs font-mono text-gray-500">探測動態工具清單</span>
+                        </div>
+                        <div class="p-6 font-mono text-sm text-gray-300 flex-1 overflow-y-auto term-scroll" id="s2-term">
+                            <div class="text-green-400 mb-2">➜ queries git:(dev) ✗ <span class="text-white">claude</span></div>
+                            <div class="mb-6"><span class="text-[#C88A64]">></span> <span class="text-gray-500 border-b border-gray-500 border-dotted cursor-pointer hover:text-white transition-colors" onclick="runS2Term()">點擊此處自動輸入探測指令</span><span class="border-r-2 border-white ml-0.5 caret-blink"></span></div>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </section>
+
+        <!-- Step 3: Parse Standard In -->
+        <section class="space-y-8">
+            <div class="flex items-start gap-4">
+                <div class="w-12 h-12 bg-[#1A1A1A] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">3</div>
+                <div>
+                    <h2 class="text-3xl font-bold mb-2">解析 Standard In (JSON Payload Diff)</h2>
+                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed">
+                        Hook 觸發時，Claude 會將 JSON 資料注入到腳本的 <code>Standard In (stdin)</code>。防禦腳本最常犯的錯就是**沒有正確處理屬性差異**。比較下方 <code>Read</code> 與 <code>Grep</code> 的結構差異。
+                    </p>
+                </div>
+            </div>
+
+            <div class="w-full overflow-x-auto no-scrollbar ml-0 md:ml-16">
+                <div class="min-w-[900px] bg-[#1A1A1A] rounded-3xl card-shadow border border-gray-800 overflow-hidden flex flex-col">
+                    
+                    <!-- Diff Tabs -->
+                    <div class="flex bg-black bg-opacity-50 border-b border-gray-800">
+                        <button onclick="setDiff('read')" id="btn-diff-read" class="px-6 py-4 font-mono text-sm font-bold text-white border-b-2 border-[#C88A64] transition-colors">
+                            Read Payload (常規)
+                        </button>
+                        <button onclick="setDiff('grep')" id="btn-diff-grep" class="px-6 py-4 font-mono text-sm font-bold text-gray-500 border-b-2 border-transparent hover:text-gray-300 transition-colors">
+                            Grep Payload (邊緣案例)
+                        </button>
+                    </div>
+
+                    <!-- Diff Content -->
+                    <div class="p-8 font-mono text-sm leading-relaxed relative min-h-[280px]">
+                        <!-- Common part -->
+                        <div class="text-gray-400">{</div>
+                        <div class="text-gray-400 pl-4">"session_id": "2d6a1e4d-6...",</div>
+                        <div class="text-gray-400 pl-4">"hook_event_name": "PreToolUse",</div>
+                        
+                        <!-- Changing part wrapper -->
+                        <div id="diff-content" class="transition-all duration-300">
+                            <!-- Injected by JS -->
+                        </div>
+
+                        <div class="text-gray-400">}</div>
+                        
+                        <!-- Note -->
+                        <div class="absolute bottom-6 right-8 bg-[#C88A64] bg-opacity-10 border border-[#C88A64] text-[#C88A64] px-4 py-3 rounded-xl text-xs max-w-sm flex gap-3 items-start">
+                            <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                            <p id="diff-note">你的解析器必須擷取 <code>file_path</code> 來檢查是否為敏感檔案。</p>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </section>
+
+        <!-- Step 4: Exit Codes & Logic Builder -->
+        <section class="space-y-8">
+            <div class="flex items-start gap-4">
+                <div class="w-12 h-12 bg-[#C88A64] text-white rounded-2xl flex items-center justify-center font-black text-2xl shadow-lg shrink-0">4</div>
+                <div class="flex-1">
+                    <h2 class="text-3xl font-bold mb-2">決策與反饋：防禦腳本編譯與測試實驗室</h2>
+                    <p class="text-gray-600 text-lg max-w-3xl leading-relaxed mb-6">
+                        之前的設計確實違反直覺，因為它把「寫腳本」跟「執行測試」混在一起了！<br>
+                        好的開發者體驗應該是：<strong>先設定好你的防禦邏輯 (Script Builder)，再丟入不同的檔案來進行測試 (Test Lab)。</strong>
+                    </p>
+                    
+                    <div class="w-full overflow-x-auto no-scrollbar flex flex-col gap-6">
+                        
+                        <!-- Top: Script Builder -->
+                        <div class="min-w-[950px] bg-white rounded-3xl card-shadow border border-gray-200 flex overflow-hidden">
+                            <!-- Left: Configuration Panel -->
+                            <div class="w-[45%] bg-gray-50 border-r border-gray-200 flex flex-col">
+                                <div class="px-6 py-4 border-b border-gray-200 bg-white font-bold text-gray-800 flex items-center justify-between">
+                                    <span>1. 腳本邏輯設定 (Script Builder)</span>
+                                </div>
+                                <div class="p-6 flex-1 space-y-6">
+                                    
+                                    <div>
+                                        <label class="block text-sm font-bold text-gray-700 mb-2">A. 攔截條件 (If matches):</label>
+                                        <select id="s4-if-cond" onchange="updateScriptPreview()" class="w-full bg-white border-2 border-gray-200 rounded-xl px-4 py-3 text-sm font-mono focus:border-[#C88A64] outline-none">
+                                            <option value="env">*".env"* (僅攔截機密檔案)</option>
+                                            <option value="all">"*" (攔截所有檔案)</option>
+                                        </select>
+                                    </div>
+
+                                    <div>
+                                        <label class="block text-sm font-bold text-gray-700 mb-2">B. 條件成立時的動作 (Action):</label>
+                                        <div class="flex bg-white border-2 border-gray-200 rounded-xl overflow-hidden text-sm font-mono">
+                                            <button id="s4-btn-exit2" onclick="setIfExit(2)" class="flex-1 py-3 bg-red-50 text-red-700 font-bold border-r-2 border-gray-200 transition-colors">Exit 2 (Block)</button>
+                                            <button id="s4-btn-exit0" onclick="setIfExit(0)" class="flex-1 py-3 text-gray-500 hover:bg-gray-50 transition-colors">Exit 0 (Allow)</button>
+                                        </div>
+                                    </div>
+
+                                    <div id="s4-stderr-container">
+                                        <label class="block text-sm font-bold text-gray-700 mb-2">C. 拒絕理由 (Stderr feedback):</label>
+                                        <input type="text" id="s4-stderr" value="Access Denied: .env files are restricted." onkeyup="updateScriptPreview()" class="w-full bg-white border-2 border-gray-200 rounded-xl px-4 py-3 text-sm font-mono focus:border-[#C88A64] outline-none">
+                                    </div>
+
+                                    <div class="pt-4 border-t border-gray-200">
+                                        <label class="block text-sm font-bold text-gray-700 mb-2">D. 預設行為 (Default Action):</label>
+                                        <select id="s4-def-exit" onchange="updateScriptPreview()" class="w-full bg-white border-2 border-gray-200 rounded-xl px-4 py-3 text-sm font-mono focus:border-[#C88A64] outline-none">
+                                            <option value="0">Exit 0 (預設放行其餘檔案)</option>
+                                            <option value="2">Exit 2 (預設全面封殺)</option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Right: Live Code Preview -->
+                            <div class="w-[55%] flex flex-col bg-[#1A1A1A] text-gray-300 font-mono text-[13px]">
+                                <div class="px-5 py-3 border-b border-gray-800 flex justify-between bg-black bg-opacity-40">
+                                    <span class="text-gray-400">hook_script.sh (即時編譯)</span>
+                                    <span class="text-[#C88A64]">Bash</span>
+                                </div>
+                                <div class="p-6 flex-1 bg-[#1A1A1A] leading-relaxed relative">
+                                    <div class="text-gray-500 italic mb-4"># Extract path from stdin</div>
+                                    <div class="text-blue-400">TARGET_PATH<span class="text-white">=</span><span class="text-gray-400">$(cat - | jq -r '.tool_input.file_path')</span></div>
+                                    <br>
+                                    
+                                    <!-- Dynamic IF Block -->
+                                    <div class="relative">
+                                        <div id="live-if-strip" class="absolute -left-4 top-0 bottom-0 w-1 bg-[#C88A64] opacity-50 rounded-r"></div>
+                                        <div class="text-purple-400">if <span class="text-white">[[</span> <span class="text-gray-300">"$TARGET_PATH"</span> <span class="text-white">==</span> <span class="text-green-300" id="live-if-cond">*".env"*</span> <span class="text-white">]];</span> then</div>
+                                        <div id="live-stderr-block" class="pl-4 mt-1">
+                                            <span class="text-blue-300">echo</span> <span class="text-green-300">"<span id="live-stderr-text">Access Denied: .env files are restricted.</span>"</span> <span class="text-red-400">>&2</span>
+                                        </div>
+                                        <div class="pl-4 mt-1">
+                                            <span class="text-blue-300">exit</span> <span id="live-if-exit" class="text-red-400 font-bold">2</span>
+                                        </div>
+                                        <div class="text-purple-400">fi</div>
+                                    </div>
+
+                                    <br>
+                                    <div class="text-gray-500 italic"># Default behavior</div>
+                                    <div class="text-blue-300">exit <span id="live-def-exit" class="text-green-400 font-bold">0</span></div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Bottom: Test Lab -->
+                        <div class="min-w-[950px] bg-[#1A1A1A] rounded-3xl card-shadow border border-gray-800 overflow-hidden flex flex-col">
+                            <div class="bg-gray-900 px-6 py-4 border-b border-gray-800 flex items-center justify-between">
+                                <span class="font-bold text-white">2. 測試實驗室 (Test Lab)</span>
+                            </div>
+                            <div class="flex p-6 gap-6">
+                                <div class="w-1/3 flex flex-col gap-4">
+                                    <div class="text-sm font-mono text-gray-400 mb-2">請選擇模擬輸入檔案：</div>
+                                    <button onclick="runTest('danger')" class="w-full bg-red-900 bg-opacity-20 hover:bg-opacity-40 border border-red-800 text-red-300 font-bold py-4 rounded-xl transition-all text-sm font-mono flex flex-col items-center gap-1">
+                                        <span>[ 測試讀取 .env ]</span>
+                                        <span class="text-[10px] font-normal text-red-400/60">應觸發攔截規則</span>
+                                    </button>
+                                    <button onclick="runTest('safe')" class="w-full bg-green-900 bg-opacity-20 hover:bg-opacity-40 border border-green-800 text-green-300 font-bold py-4 rounded-xl transition-all text-sm font-mono flex flex-col items-center gap-1">
+                                        <span>[ 測試讀取 package.json ]</span>
+                                        <span class="text-[10px] font-normal text-green-400/60">應觸發預設規則</span>
+                                    </button>
+                                </div>
+                                <div class="w-2/3 bg-black rounded-xl border border-gray-800 flex flex-col">
+                                    <div class="px-4 py-2 text-[11px] text-gray-500 border-b border-gray-800 uppercase tracking-widest">Claude Context Engine Output</div>
+                                    <div id="s4-term-out" class="p-4 overflow-y-auto term-scroll flex-1 text-xs font-mono space-y-1.5 h-48">
+                                        <div class="text-gray-600">等待測試觸發...</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <script>
+        // --- Step 1: Pre vs Post Animation ---
+        let s1Type = 'pre';
+        function runStep1(type) {
+            s1Type = type;
+            const btnPre = document.getElementById('s1-btn-pre');
+            const btnPost = document.getElementById('s1-btn-post');
+            const hookWall = document.getElementById('s1-hook-wall');
+            const shield = document.getElementById('s1-shield');
+            const label = document.getElementById('s1-hook-label');
+            const targetFile = document.getElementById('s1-target-file');
+
+            // Reset UI
+            targetFile.className = 'w-16 h-16 bg-white border-2 border-gray-300 text-gray-500 rounded-2xl flex items-center justify-center shadow-sm mx-auto mb-3 transition-colors duration-300';
+            document.getElementById('s1-packet').style.opacity = '0';
+            document.getElementById('s1-packet').style.left = '24px';
+            const feedback = document.getElementById('s1-feedback');
+            feedback.style.opacity = '0';
+            feedback.className = 'absolute bottom-6 left-1/2 -translate-x-1/2 bg-white px-6 py-3 rounded-xl shadow-xl border border-gray-100 text-sm font-bold opacity-0 transition-opacity flex items-center gap-2';
+
+
+            if(type === 'pre') {
+                btnPre.className = 'w-full text-left px-5 py-4 bg-[#1A1A1A] text-white rounded-xl font-bold shadow-md ring-2 ring-[#C88A64] ring-offset-2 transition-all';
+                btnPost.className = 'w-full text-left px-5 py-4 bg-gray-50 text-gray-600 hover:bg-gray-100 rounded-xl font-bold border border-gray-200 transition-all';
+                
+                // Position wall in the middle
+                hookWall.style.left = '50%';
+                shield.className = 'w-20 h-24 bg-[#C88A64] rounded-xl flex items-center justify-center shadow-2xl border-4 border-white transition-colors duration-300';
+                label.innerText = 'PreToolUse';
+            } else {
+                btnPost.className = 'w-full text-left px-5 py-4 bg-[#1A1A1A] text-white rounded-xl font-bold shadow-md ring-2 ring-[#C88A64] ring-offset-2 transition-all';
+                btnPre.className = 'w-full text-left px-5 py-4 bg-gray-50 text-gray-600 hover:bg-gray-100 rounded-xl font-bold border border-gray-200 transition-all';
+                
+                // Position wall AFTER the file
+                hookWall.style.left = '85%';
+                shield.className = 'w-20 h-24 bg-gray-400 rounded-xl flex items-center justify-center shadow-2xl border-4 border-white transition-colors duration-300';
+                label.innerText = 'PostToolUse';
+            }
+        }
+
+        function playStep1() {
+            const packet = document.getElementById('s1-packet');
+            const targetFile = document.getElementById('s1-target-file');
+            const feedback = document.getElementById('s1-feedback');
+            const shield = document.getElementById('s1-shield');
+            
+            // Reset
+            packet.style.transition = 'none';
+            packet.style.left = '10%';
+            packet.style.opacity = '1';
+            feedback.style.opacity = '0';
+            targetFile.className = 'w-16 h-16 bg-white border-2 border-gray-300 text-gray-500 rounded-2xl flex items-center justify-center shadow-sm mx-auto mb-3 transition-colors duration-300';
+
+            // Trigger reflow
+            void packet.offsetWidth;
+            packet.style.transition = 'all 800ms ease-in-out';
+
+            if(s1Type === 'pre') {
+                packet.style.left = '45%'; // hits the wall
+                setTimeout(() => {
+                    shield.classList.replace('bg-[#C88A64]', 'bg-red-500');
+                    setTimeout(() => shield.classList.replace('bg-red-500', 'bg-[#C88A64]'), 500);
+                    
+                    feedback.innerHTML = '<span class="w-3 h-3 rounded-full bg-green-500"></span><span class="text-green-600">成功在讀取前攔截操作！檔案安全。</span>';
+                    feedback.style.opacity = '1';
+                    packet.style.opacity = '0';
+                }, 800);
+            } else {
+                packet.style.left = '100%'; // passes through
+                setTimeout(() => {
+                    targetFile.classList.replace('border-gray-300', 'border-red-500');
+                    targetFile.classList.replace('text-gray-500', 'text-red-500');
+                    targetFile.classList.add('bg-red-50');
+                }, 500); // changes color as packet passes
+
+                setTimeout(() => {
+                    shield.classList.replace('bg-gray-400', 'bg-red-500');
+                    setTimeout(() => shield.classList.replace('bg-red-500', 'bg-gray-400'), 500);
+
+                    feedback.innerHTML = '<span class="w-3 h-3 rounded-full bg-red-500"></span><span class="text-red-600">嚴重：檔案已被讀取！PostToolUse 攔截無效。</span>';
+                    feedback.style.opacity = '1';
+                    packet.style.opacity = '0';
+                }, 800);
+            }
+        }
+        runStep1('pre'); // Init
+
+
+        // --- Step 2: Terminal Typing ---
+        let s2IsTyping = false;
+        async function runS2Term() {
+            if(s2IsTyping) return;
+            s2IsTyping = true;
+            const term = document.getElementById('s2-term');
+            term.innerHTML = '<div class="text-green-400 mb-2">➜ queries git:(dev) ✗ <span class="text-white">claude</span></div>';
+            
+            const promptLine = document.createElement('div');
+            promptLine.className = 'mb-4 text-white';
+            promptLine.innerHTML = '<span class="text-[#C88A64]">></span> <span id="s2-type-target"></span><span class="border-r-2 border-white ml-0.5 caret-blink"></span>';
+            term.appendChild(promptLine);
+
+            const target = document.getElementById('s2-type-target');
+            const msg = "List out the names of all the tools you have access to, bullet point list.";
+            for(let i=0; i<msg.length; i++){
+                target.innerHTML += msg[i];
+                await new Promise(r => setTimeout(r, 20)); // typing speed
+            }
+
+            const thinkingLine = document.createElement('div');
+            thinkingLine.className = 'text-gray-500 italic mb-4 mt-2';
+            thinkingLine.innerText = '* Imagining...';
+            term.appendChild(thinkingLine);
+            await new Promise(r => setTimeout(r, 600));
+            thinkingLine.remove();
+
+            const output = document.createElement('div');
+            output.className = 'text-gray-300 fade-in space-y-2 pb-6';
+            output.innerHTML = `
+                <p>Here are the tools I have access to:</p>
+                <ul class="list-disc pl-5 font-mono">
+                    <li>Bash</li>
+                    <li class="bg-red-900 bg-opacity-30 text-red-200 inline-block px-1 rounded my-1 font-bold">Grep  <span class="text-xs font-normal text-red-400 ml-2">&lt;- ⚠️ Danger: File Access</span></li>
+                    <br>
+                    <li>Edit</li>
+                    <li class="bg-[#C88A64] bg-opacity-20 text-[#C88A64] inline-block px-1 rounded my-1 font-bold">Read  <span class="text-xs font-normal text-[#C88A64] ml-2">&lt;- 🎯 Target: File Access</span></li>
+                    <br>
+                    <li>Write</li>
+                    <li class="text-purple-400">MCP_Server_GitSearch</li>
+                    <li class="text-purple-400">MCP_Server_DBQuery</li>
+                </ul>
+                <p class="text-gray-500 text-xs mt-4 border-t border-gray-800 pt-2">/* 工具清單是動態的，依賴你掛載的 MCP Servers */</p>
+            `;
+            term.appendChild(output);
+            term.scrollTop = term.scrollHeight;
+            s2IsTyping = false;
+        }
+
+        // --- Step 3: JSON Diff ---
+        const diffPayloads = {
+            read: `
+<div class="text-[#C88A64] pl-4 font-bold">"tool_name": <span class="text-yellow-300">"Read"</span>,</div>
+<div class="text-[#C88A64] pl-4 font-bold">"tool_input": {</div>
+<div class="pl-8 bg-[#1A1A1A] border-l-2 border-[#C88A64] py-1 my-1 flex items-center">
+    <span class="text-blue-300">"file_path"</span><span class="text-gray-400">: </span><span class="text-green-300">"/code/queries/.env"</span>
+</div>
+<div class="text-[#C88A64] pl-4 font-bold">}</div>`,
+            grep: `
+<div class="text-[#C88A64] pl-4 font-bold">"tool_name": <span class="text-yellow-300">"Grep"</span>,</div>
+<div class="text-[#C88A64] pl-4 font-bold">"tool_input": {</div>
+<div class="pl-8 py-1"><span class="text-blue-300">"pattern"</span><span class="text-gray-400">: </span><span class="text-green-300">"SECRET"</span>,</div>
+<div class="pl-8 bg-[#1A1A1A] border-l-2 border-red-500 py-1 my-1 flex items-center">
+    <span class="text-blue-300">"target_path"</span><span class="text-gray-400">: </span><span class="text-green-300">"/code/queries/.env"</span>
+</div>
+<div class="text-[#C88A64] pl-4 font-bold">}</div>`
+        };
+
+        function setDiff(type) {
+            const btnR = document.getElementById('btn-diff-read');
+            const btnG = document.getElementById('btn-diff-grep');
+            const content = document.getElementById('diff-content');
+            const note = document.getElementById('diff-note');
+
+            content.classList.remove('fade-in');
+            void content.offsetWidth; // trigger reflow
+
+            if(type === 'read') {
+                btnR.className = 'px-6 py-4 font-mono text-sm font-bold text-white border-b-2 border-[#C88A64] transition-colors';
+                btnG.className = 'px-6 py-4 font-mono text-sm font-bold text-gray-500 border-b-2 border-transparent hover:text-gray-300 transition-colors';
+                note.innerHTML = '解析器必須擷取 <code>file_path</code> 來檢查是否為敏感檔案。';
+            } else {
+                btnG.className = 'px-6 py-4 font-mono text-sm font-bold text-white border-b-2 border-red-500 transition-colors';
+                btnR.className = 'px-6 py-4 font-mono text-sm font-bold text-gray-500 border-b-2 border-transparent hover:text-gray-300 transition-colors';
+                note.innerHTML = '<strong>陷阱！</strong> 在 Grep 工具中，路徑屬性變成了 <code>target_path</code>，而非 <code>file_path</code>。腳本必須相容處理。';
+            }
+
+            content.innerHTML = diffPayloads[type];
+            content.classList.add('fade-in');
+        }
+        setDiff('read'); // Init
+
+        // --- Step 4: Logic Builder & Execution ---
+        let currentIfExit = 2;
+        
+        function setIfExit(code) {
+            currentIfExit = code;
+            const btn2 = document.getElementById('s4-btn-exit2');
+            const btn0 = document.getElementById('s4-btn-exit0');
+            const stderrContainer = document.getElementById('s4-stderr-container');
+
+            if(code === 2) {
+                btn2.className = 'flex-1 py-3 bg-red-50 text-red-700 font-bold border-r-2 border-gray-200 transition-colors';
+                btn0.className = 'flex-1 py-3 text-gray-500 hover:bg-gray-50 transition-colors';
+                stderrContainer.style.opacity = '1';
+                stderrContainer.style.pointerEvents = 'auto';
+            } else {
+                btn0.className = 'flex-1 py-3 bg-gray-200 text-gray-800 font-bold transition-colors';
+                btn2.className = 'flex-1 py-3 text-gray-500 hover:bg-gray-50 border-r-2 border-gray-200 transition-colors';
+                stderrContainer.style.opacity = '0.4';
+                stderrContainer.style.pointerEvents = 'none';
+            }
+            updateScriptPreview();
+        }
+
+        function updateScriptPreview() {
+            const ifCond = document.getElementById('s4-if-cond').value;
+            const stderrVal = document.getElementById('s4-stderr').value;
+            const defExit = document.getElementById('s4-def-exit').value;
+
+            // Cond
+            document.getElementById('live-if-cond').innerText = ifCond === 'env' ? '*".env"*' : '"*"';
+            
+            // Exit in IF
+            const liveIfExit = document.getElementById('live-if-exit');
+            const liveStderrBlock = document.getElementById('live-stderr-block');
+            const liveIfStrip = document.getElementById('live-if-strip');
+
+            document.getElementById('live-stderr-text').innerText = stderrVal;
+
+            if (currentIfExit === 2) {
+                liveIfExit.innerText = '2';
+                liveIfExit.className = 'text-red-400 font-bold';
+                liveStderrBlock.style.opacity = '1';
+                liveIfStrip.className = 'absolute -left-4 top-0 bottom-0 w-1 bg-[#C88A64] opacity-50 rounded-r';
+            } else {
+                liveIfExit.innerText = '0';
+                liveIfExit.className = 'text-green-400 font-bold';
+                liveStderrBlock.style.opacity = '0.3';
+                liveIfStrip.className = 'absolute -left-4 top-0 bottom-0 w-1 bg-yellow-500 opacity-50 rounded-r';
+            }
+
+            // Default Exit
+            const liveDefExit = document.getElementById('live-def-exit');
+            liveDefExit.innerText = defExit;
+            liveDefExit.className = defExit === '0' ? 'text-green-400 font-bold' : 'text-red-400 font-bold';
+        }
+
+        function runTest(testType) {
+            const ifCond = document.getElementById('s4-if-cond').value;
+            const defExit = document.getElementById('s4-def-exit').value;
+            const stderrVal = document.getElementById('s4-stderr').value;
+            
+            const targetPath = testType === 'danger' ? '/code/queries/.env' : '/code/queries/package.json';
+            const term = document.getElementById('s4-term-out');
+            
+            term.innerHTML = '';
+            const log = (html, delay) => {
+                setTimeout(() => {
+                    const el = document.createElement('div');
+                    el.innerHTML = html;
+                    el.className = 'fade-in';
+                    term.appendChild(el);
+                    term.scrollTop = term.scrollHeight;
+                }, delay);
+            }
+
+            log('<span class="text-blue-400">></span> 注入輸入：<code>TARGET_PATH="' + targetPath + '"</code>', 100);
+            log('<span class="text-gray-500">></span> 執行腳本檢測...', 400);
+
+            let isMatch = false;
+            if (ifCond === 'all') {
+                isMatch = true;
+            } else if (ifCond === 'env' && testType === 'danger') {
+                isMatch = true;
+            }
+
+            if (isMatch) {
+                log('<span class="text-purple-400">> 條件成立，進入 if 區塊。</span>', 800);
+                
+                if (currentIfExit === 2) {
+                    log('<span class="text-red-400">> 觸發 exit 2 (中斷)</span>', 1200);
+                    log('<div class="mt-2 bg-red-900/30 border border-red-800 p-2 rounded text-red-200 font-bold">[TOOL BLOCKED] Claude 操作已被成功阻擋！</div>', 1600);
+                    log('<div class="mt-1 text-[#C88A64]">Claude 收到回饋: <span class="text-gray-300">"' + stderrVal + '"</span></div>', 1800);
+                } else {
+                    log('<span class="text-green-400">> 觸發 exit 0 (放行)</span>', 1200);
+                    log('<div class="mt-2 bg-yellow-900/30 border border-yellow-800 p-2 rounded text-yellow-200 font-bold">⚠️ [邏輯漏洞] 你攔截了檔案卻設定放行！</div>', 1600);
+                    log('<div class="mt-1 text-green-400 font-bold">[ALL IS WELL] Claude 成功讀取檔案。 (可能導致機密外洩)</div>', 1800);
+                }
+            } else {
+                log('<span class="text-gray-500">> 條件不成立，跳過 if 區塊。</span>', 800);
+                
+                if (defExit === '0') {
+                    log('<span class="text-green-400">> 腳本結束，觸發預設 exit 0</span>', 1200);
+                    log('<div class="mt-2 bg-green-900/20 border border-green-800 p-2 rounded text-green-400 font-bold">[ALL IS WELL] 正常檔案已被放行，操作繼續。</div>', 1600);
+                } else {
+                    log('<span class="text-red-400">> 腳本結束，觸發預設 exit 2</span>', 1200);
+                    log('<div class="mt-2 bg-red-900/30 border border-red-800 p-2 rounded text-red-200 font-bold">[TOOL BLOCKED] 檔案被預設防禦規則阻擋。</div>', 1600);
+                }
+            }
+        }
+    </script>
+</body>
+</html>

--- a/public/2026-plan/section3/312003-implementing-a-hook.html
+++ b/public/2026-plan/section3/312003-implementing-a-hook.html
@@ -1,0 +1,727 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code Hook 深度互動模擬器</title>
+    
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,700;1,400&family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
+    
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        beige: '#F8F8F5',
+                        dark: '#1A1A1A',
+                        caramel: '#C88A64',
+                        danger: '#ef4444',
+                        success: '#22c55e',
+                        warning: '#eab308'
+                    },
+                    fontFamily: {
+                        sans: ['"Noto Sans TC"', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'monospace'],
+                    }
+                }
+            }
+        }
+    </script>
+
+    <style>
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+        .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+        
+        body { background-color: #F8F8F5; color: #1A1A1A; }
+        
+        /* Interactive Elements styling */
+        .glass-panel { background: #FFFFFF; border: 2px solid #1A1A1A; box-shadow: 6px 6px 0px #C88A64; transition: transform 0.1s, box-shadow 0.1s; }
+        .glass-panel:active { transform: translate(2px, 2px); box-shadow: 4px 4px 0px #C88A64; }
+        
+        .code-block { background: #1A1A1A; color: #F8F8F5; }
+
+        /* Routing Animation Paths */
+        .path-line { stroke-dasharray: 8 8; animation: movePath 0.8s linear infinite reverse; }
+        @keyframes movePath { to { stroke-dashoffset: 16; } }
+        
+        /* Terminal Blinking Cursor */
+        .cursor-blink { animation: blink 1s step-end infinite; border-left: 8px solid #C88A64; margin-left: 2px;}
+        @keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+
+        /* Custom Textarea for Code Editor */
+        #user-code-input {
+            background: transparent;
+            color: #C88A64;
+            caret-color: #C88A64;
+            resize: none;
+            outline: none;
+            field-sizing: content;
+            min-height: 24px;
+        }
+        #user-code-input::selection { background: #C88A64; color: #1A1A1A; }
+
+        /* Checklist Animations */
+        .check-item { transition: all 0.3s ease; }
+        .check-item.done { opacity: 0.5; text-decoration: line-through; }
+        .check-item.done .box { background-color: #22c55e; border-color: #22c55e; }
+    </style>
+</head>
+<body class="antialiased selection:bg-caramel selection:text-white pb-32">
+
+    <!-- Header -->
+    <header class="bg-dark text-beige py-12 px-6 border-b-8 border-caramel relative overflow-hidden">
+        <div class="max-w-6xl mx-auto relative z-10 flex flex-col md:flex-row items-start md:items-center justify-between gap-6">
+            <div>
+                <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full border border-caramel bg-caramel/20 text-caramel text-sm font-mono mb-4 font-bold tracking-widest">
+                    INTERACTIVE LAB v2.2
+                </div>
+                <h1 class="text-4xl md:text-5xl font-black mb-2">Claude Code: Hook 機制深度模擬器</h1>
+                <p class="text-beige/70 text-lg max-w-2xl">不要只看文件，動手搞壞它。透過親自配置路由、編寫攔截邏輯與體驗重啟陷阱，真正掌握 PreToolUse Hook 的底層原理與邊界防護。</p>
+            </div>
+            <!-- Progress Tracker -->
+            <div class="flex gap-2">
+                <div id="badge-1" class="w-10 h-10 rounded-full border-2 border-beige/30 flex items-center justify-center font-mono font-bold text-beige/30 transition-all">1</div>
+                <div id="badge-2" class="w-10 h-10 rounded-full border-2 border-beige/30 flex items-center justify-center font-mono font-bold text-beige/30 transition-all">2</div>
+                <div id="badge-3" class="w-10 h-10 rounded-full border-2 border-beige/30 flex items-center justify-center font-mono font-bold text-beige/30 transition-all">3</div>
+            </div>
+        </div>
+    </header>
+
+    <main class="max-w-6xl mx-auto px-6 mt-12 space-y-24">
+
+        <!-- Module 1: The Matcher Router -->
+        <section id="module-1" class="scroll-mt-12">
+            <div class="mb-6 flex justify-between items-end">
+                <div>
+                    <h2 class="text-3xl font-black mb-2 flex items-center gap-3">
+                        <span class="w-10 h-10 rounded bg-dark text-white flex items-center justify-center font-mono text-xl shadow-[4px_4px_0_#C88A64]">1</span>
+                        動態路由模擬：Matcher 是第一道閘門
+                    </h2>
+                    <p class="text-dark/80 max-w-3xl">Claude Code 會根據 `settings.local.json` 中的 `matcher` 決定是否要將 Tool 請求拋給你的 Node.js 腳本。如果 Matcher 沒對到，你的腳本連執行的機會都沒有。請嘗試不同的組合！</p>
+                </div>
+            </div>
+
+            <div class="w-full overflow-x-auto no-scrollbar">
+                <div class="min-w-[900px] bg-white border-2 border-dark rounded-2xl p-8 relative flex flex-col items-center">
+                    <!-- Controls -->
+                    <div class="flex justify-between w-full mb-12 relative z-10 gap-8">
+                        <!-- Left: Claude Request -->
+                        <div class="w-1/3 bg-beige border-2 border-dark p-4 rounded-xl">
+                            <div class="text-xs font-mono font-bold text-dark/50 mb-2">Claude 想要執行...</div>
+                            <select id="router-tool-select" class="w-full bg-white border-2 border-dark rounded p-2 font-mono font-bold text-lg outline-none focus:border-caramel">
+                                <option value="Read">Read (.env)</option>
+                                <option value="Grep">Grep (API_KEY)</option>
+                                <option value="Bash">Bash (cat .env)</option>
+                            </select>
+                        </div>
+
+                        <!-- Center: Matcher Config -->
+                        <div class="w-1/3 bg-dark text-beige p-4 rounded-xl shadow-[4px_4px_0_#C88A64] z-20">
+                            <div class="text-xs font-mono font-bold text-caramel mb-2">你的 settings.json Matcher</div>
+                            <select id="router-matcher-select" class="w-full bg-[#2A2A2A] border-2 border-caramel rounded p-2 font-mono font-bold text-lg text-white outline-none">
+                                <option value="Read">"Read"</option>
+                                <option value="Read|Grep">"Read|Grep"</option>
+                                <option value="*">"*" (All Tools)</option>
+                            </select>
+                        </div>
+                        
+                        <!-- Right: Action -->
+                        <div class="w-1/3 flex items-center justify-end">
+                            <button id="btn-fire-route" class="glass-panel bg-caramel text-dark font-black px-8 py-4 text-xl rounded-xl w-full">
+                                發送請求 (Fire!)
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Visual Pipeline -->
+                    <div class="relative w-full h-48 bg-beige/50 border-2 border-dark/10 rounded-xl overflow-hidden flex items-center justify-between px-12">
+                        <svg class="absolute inset-0 w-full h-full" style="z-index: 0;">
+                            <path d="M 50 96 L 400 96" stroke="#1A1A1A" stroke-width="4" stroke-opacity="0.1" fill="none" />
+                            <path id="svg-path-hook" d="M 400 96 L 400 160 L 700 160" stroke="#1A1A1A" stroke-width="4" stroke-opacity="0.1" fill="none" />
+                            <path id="svg-path-bypass" d="M 400 96 L 400 30 L 700 30" stroke="#1A1A1A" stroke-width="4" stroke-opacity="0.1" fill="none" />
+                        </svg>
+                        <svg class="absolute inset-0 w-full h-full pointer-events-none" style="z-index: 1;">
+                            <path id="anim-path-main" d="M 50 96 L 400 96" stroke="#C88A64" stroke-width="6" fill="none" class="opacity-0 path-line" />
+                            <path id="anim-path-hook" d="M 400 96 L 400 160 L 680 160" stroke="#C88A64" stroke-width="6" fill="none" class="opacity-0 path-line" />
+                            <path id="anim-path-bypass" d="M 400 96 L 400 30 L 680 30" stroke="#ef4444" stroke-width="6" fill="none" class="opacity-0 path-line" />
+                        </svg>
+
+                        <div class="z-10 bg-dark text-white font-mono font-bold px-4 py-2 rounded shadow-lg">Claude</div>
+                        <div class="z-10 absolute left-[380px] top-[76px] w-10 h-10 bg-dark rounded-full border-4 border-caramel flex items-center justify-center text-caramel font-bold shadow-[0_0_15px_#C88A64]" id="node-matcher">?</div>
+                        <div class="z-10 flex flex-col gap-[75px] items-end absolute right-[50px] top-[10px]">
+                            <div class="bg-danger/10 border-2 border-danger text-danger font-bold px-4 py-2 rounded-lg text-sm flex items-center gap-2" id="dest-bypass">
+                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>
+                                Bypass (危險: 直通作業系統)
+                            </div>
+                            <div class="bg-dark text-beige border-2 border-caramel font-bold px-4 py-2 rounded-lg text-sm flex items-center gap-2" id="dest-hook">
+                                <svg class="w-5 h-5 text-caramel" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                Node.js Hook 腳本
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div id="router-result" class="mt-6 font-mono font-bold text-lg h-8 text-center w-full"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Module 2: Live Code Executor -->
+        <section id="module-2" class="scroll-mt-12 opacity-50 transition-opacity duration-500 pointer-events-none">
+            <div class="mb-6 flex justify-between items-end">
+                <div>
+                    <h2 class="text-3xl font-black mb-2 flex items-center gap-3">
+                        <span class="w-10 h-10 rounded bg-dark text-white flex items-center justify-center font-mono text-xl shadow-[4px_4px_0_#C88A64]">2</span>
+                        Live Code 驗證台：為何單一腳本不可靠？
+                    </h2>
+                    <p class="text-dark/80 max-w-3xl">這是一個真正的 JavaScript 執行器。教材提到不同工具有不同的 Payload (Data Schema)。**請親自修改下方的 IF 判斷式**，然後點擊「執行測試」，看看你的防護邏輯能不能完美擋下三種工具的攻擊。</p>
+                </div>
+            </div>
+
+            <div class="w-full overflow-x-auto no-scrollbar">
+                <div class="min-w-[1000px] grid grid-cols-2 gap-6">
+                    <!-- Left: Code Editor -->
+                    <div class="code-block rounded-2xl p-6 shadow-2xl flex flex-col relative">
+                        <div class="absolute top-0 left-6 bg-caramel text-dark text-xs font-bold px-3 py-1 rounded-b-lg font-mono">read_hook.js</div>
+                        <div class="mt-6 flex-1 font-mono text-sm leading-relaxed overflow-y-auto">
+                            <div class="text-white/40">// 從 STDIN 取得 JSON 並解析</div>
+                            <div>const toolArgs = JSON.parse(input);</div>
+                            <div class="text-white/40 mt-4">// 你的安全攔截邏輯寫在這裡：</div>
+                            
+                            <div class="bg-white/5 border border-white/10 rounded-lg p-4 mt-2 mb-4 relative group">
+                                <div class="absolute -left-3 top-4 text-caramel opacity-0 group-hover:opacity-100 transition-opacity">▶</div>
+                                <span class="text-[#cc7832]">if</span> (
+                                <textarea id="user-code-input" class="w-full bg-dark/50 border border-caramel/50 p-2 rounded block my-1 font-mono text-sm" rows="1" spellcheck="false">toolArgs.tool_input.file_path.includes('.env')</textarea>
+                                ) {<br>
+                                &nbsp;&nbsp;<span class="text-[#cc7832]">console</span>.error(<span class="text-[#6a8759]">"攔截！"</span>);<br>
+                                &nbsp;&nbsp;<span class="text-[#cc7832]">process</span>.exit(<span class="text-[#6897bb]">2</span>);<br>
+                                } <span class="text-[#cc7832]">else</span> {<br>
+                                &nbsp;&nbsp;<span class="text-[#cc7832]">process</span>.exit(<span class="text-[#6897bb]">0</span>); <span class="text-white/40">// 放行</span><br>
+                                }
+                            </div>
+                        </div>
+                        <button id="btn-run-code" class="mt-4 w-full glass-panel bg-white text-dark border-2 border-dark font-black py-3 rounded-lg flex justify-center items-center gap-2 hover:bg-beige transition-colors">
+                            <svg class="w-5 h-5 text-caramel" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+                            執行測試 (對抗三種 Payload)
+                        </button>
+                    </div>
+
+                    <!-- Right: Execution Results -->
+                    <div class="bg-white border-2 border-dark rounded-2xl p-6 shadow-xl flex flex-col">
+                        <h3 class="font-bold text-lg mb-4 border-b-2 border-dark/10 pb-2">執行結果面板</h3>
+                        <div class="space-y-4 flex-1" id="test-results-container">
+                            <div class="p-4 rounded-xl border-2 border-dark/10 bg-beige transition-all" id="res-read">
+                                <div class="flex justify-between items-center mb-2">
+                                    <span class="font-mono font-bold text-dark">測試 1: Read 工具</span>
+                                    <span class="badge px-2 py-1 rounded text-xs font-bold bg-dark/10 text-dark/50">等待測試...</span>
+                                </div>
+                                <div class="text-xs font-mono bg-dark/5 p-2 rounded text-dark/70 truncate">Payload: {"tool_input": {"file_path": ".env"}}</div>
+                                <div class="msg text-sm font-bold mt-2 h-5"></div>
+                            </div>
+                            <div class="p-4 rounded-xl border-2 border-dark/10 bg-beige transition-all" id="res-grep">
+                                <div class="flex justify-between items-center mb-2">
+                                    <span class="font-mono font-bold text-dark">測試 2: Grep 工具</span>
+                                    <span class="badge px-2 py-1 rounded text-xs font-bold bg-dark/10 text-dark/50">等待測試...</span>
+                                </div>
+                                <div class="text-xs font-mono bg-dark/5 p-2 rounded text-dark/70 truncate">Payload: {"tool_input": {"pattern": "API", "path": "/"}}</div>
+                                <div class="msg text-sm font-bold mt-2 h-5"></div>
+                            </div>
+                            <div class="p-4 rounded-xl border-2 border-dark/10 bg-beige transition-all" id="res-bash">
+                                <div class="flex justify-between items-center mb-2">
+                                    <span class="font-mono font-bold text-dark">測試 3: Bash 工具</span>
+                                    <span class="badge px-2 py-1 rounded text-xs font-bold bg-dark/10 text-dark/50">等待測試...</span>
+                                </div>
+                                <div class="text-xs font-mono bg-dark/5 p-2 rounded text-dark/70 truncate">Payload: {"tool_input": {"command": "cat .env"}}</div>
+                                <div class="msg text-sm font-bold mt-2 h-5"></div>
+                            </div>
+                        </div>
+                        <div id="module-2-conclusion" class="mt-4 p-4 bg-caramel/20 border-l-4 border-caramel rounded-r text-sm font-bold text-dark hidden">
+                            看到了嗎？只要有一個 Schema 不合，你的 Hook 就會崩潰或漏接。這就是為什麼 Senior 教材強烈建議：**不要用單一 Hook 處理所有工具，請愛用原生的 `permissions.deny` 進行全域封鎖。**
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Module 3: Terminal Gotcha Escape Room (REFACTORED V2) -->
+        <section id="module-3" class="scroll-mt-12 opacity-50 transition-opacity duration-500 pointer-events-none relative">
+            <div class="mb-6 flex justify-between items-end border-b-2 border-dark/10 pb-6">
+                <div>
+                    <h2 class="text-3xl font-black mb-2 flex items-center gap-3">
+                        <span class="w-10 h-10 rounded bg-dark text-white flex items-center justify-center font-mono text-xl shadow-[4px_4px_0_#C88A64]">3</span>
+                        DX 狀態機：重啟陷阱密室逃脫
+                    </h2>
+                    <p class="text-dark/80 max-w-3xl">這是實務上最多人踩的坑。**修改 Hook 檔案後如果沒有重啟 Claude Code，設定是不會生效的！** 請跟隨右方的「任務清單」指示，一步步體驗並破解這個地雷。</p>
+                </div>
+                
+                <button id="btn-reset-m3" class="bg-white border-2 border-dark text-dark px-4 py-2 rounded-lg font-bold hover:bg-dark hover:text-white transition-colors flex items-center gap-2 text-sm shadow-[4px_4px_0_#1A1A1A] active:translate-y-1 active:translate-x-1 active:shadow-none">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>
+                    重新挑戰
+                </button>
+            </div>
+
+            <!-- GUIDED CHECKLIST - REFINED -->
+            <div class="mb-6 bg-white border-2 border-dark rounded-xl p-5 shadow-sm flex flex-col md:flex-row gap-6 items-center">
+                <div class="font-bold text-dark w-full md:w-auto text-lg whitespace-nowrap">🎯 逃脫任務：</div>
+                <div class="flex-1 flex flex-col md:flex-row gap-4 text-sm font-bold text-dark/60 w-full justify-between">
+                    <div id="task-1" class="check-item flex items-center gap-2">
+                        <div class="box w-5 h-5 rounded border-2 border-dark/30 flex items-center justify-center text-white text-xs"></div>
+                        1. 輸入 <code class="bg-dark/10 px-1 rounded text-dark font-mono">read .env</code> 觸發漏洞
+                    </div>
+                    <div id="task-2" class="check-item flex items-center gap-2">
+                        <div class="box w-5 h-5 rounded border-2 border-dark/30 flex items-center justify-center text-white text-xs"></div>
+                        2. 修改設定檔並點擊「重啟按鈕」
+                    </div>
+                    <div id="task-3" class="check-item flex items-center gap-2">
+                        <div class="box w-5 h-5 rounded border-2 border-dark/30 flex items-center justify-center text-white text-xs"></div>
+                        3. 再次輸入 <code class="bg-dark/10 px-1 rounded text-dark font-mono">read .env</code> 驗證攔截
+                    </div>
+                </div>
+            </div>
+
+            <div class="w-full overflow-x-auto no-scrollbar">
+                <div class="min-w-[1000px] bg-[#1E1E1E] rounded-2xl border-4 border-dark overflow-hidden shadow-[8px_8px_0_#C88A64] flex flex-col relative pb-0 mb-4">
+                    
+                    <div class="bg-dark px-4 py-2 flex justify-between items-center border-b-2 border-black">
+                        <div class="text-beige/50 font-mono text-xs">Sandbox Engine v1.1</div>
+                        <div id="sync-status" class="flex items-center gap-2 px-3 py-1 rounded-full bg-success/20 border border-success/30 text-success text-xs font-bold transition-colors">
+                            <div class="w-2 h-2 rounded-full bg-success"></div>
+                            狀態同步：磁碟設定與記憶體一致
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-12 gap-0 flex-1">
+                        <!-- Left: VS Code Config Editor -->
+                        <div class="col-span-5 bg-[#252526] border-r border-black/50 flex flex-col relative">
+                            <div class="bg-[#2D2D2D] px-4 py-2 flex items-center text-white/50 text-xs font-sans gap-2 justify-between">
+                                <div class="flex items-center gap-2">
+                                    <svg class="w-4 h-4 text-[#F34B7D]" fill="currentColor" viewBox="0 0 24 24"><path d="M4 4h16v16H4V4zm2 2v12h12V6H6z"/></svg>
+                                    settings.local.json
+                                </div>
+                            </div>
+                            
+                            <div class="p-6 font-mono text-[13px] text-[#D4D4D4] flex-1 leading-loose relative">
+                                {<br>
+                                &nbsp;&nbsp;"hooks": {<br>
+                                &nbsp;&nbsp;&nbsp;&nbsp;"PreToolUse": [<br>
+                                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{<br>
+                                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"matcher": <span class="text-[#CE9178]">"Read"</span>,<br>
+                                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"command": 
+                                <button id="btn-edit-config" class="bg-[#3A3D41] hover:bg-[#4A4D51] text-[#CE9178] border border-[#5A5D61] px-2 py-0.5 rounded transition-all active:scale-95 group relative ml-1 inline-flex items-center gap-2">
+                                    <span id="config-text">"true"</span>
+                                    <svg class="w-3 h-3 text-[#D4D4D4] group-hover:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"></path></svg>
+                                    
+                                    <div class="absolute -top-10 left-1/2 -translate-x-1/2 bg-caramel text-dark text-xs font-bold px-2 py-1 rounded whitespace-nowrap opacity-100 animate-bounce pointer-events-none" id="edit-hint">
+                                        點擊掛載 Hook 腳本 ↓
+                                    </div>
+                                </button>
+                                <br>
+                                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}<br>
+                                &nbsp;&nbsp;&nbsp;&nbsp;]<br>
+                                &nbsp;&nbsp;}<br>
+                                }
+                                
+                                <div id="file-saved-toast" class="absolute bottom-4 right-4 bg-success/20 border border-success/50 text-success font-bold text-xs px-3 py-1.5 rounded opacity-0 transition-opacity flex items-center gap-1">
+                                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                    檔案已修改
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Right: Claude Code Terminal -->
+                        <div class="col-span-7 bg-[#1E1E1E] flex flex-col relative">
+                            <!-- Toolbar -->
+                            <div class="bg-[#2D2D2D] px-4 py-3 flex items-center justify-between border-b border-black/50">
+                                <div class="flex gap-1.5">
+                                    <div class="w-3 h-3 rounded-full bg-[#FF5F56]"></div>
+                                    <div class="w-3 h-3 rounded-full bg-[#FFBD2E]"></div>
+                                    <div class="w-3 h-3 rounded-full bg-[#27C93F]"></div>
+                                </div>
+                                
+                                <div class="flex gap-4 items-center">
+                                    <div class="text-xs font-mono text-white/50 flex items-center gap-1">
+                                        Claude 記憶體載入狀態: 
+                                        <span id="mem-state-indicator" class="text-danger font-bold bg-danger/10 px-1 rounded border border-danger/30">"true" (無防護)</span>
+                                    </div>
+                                    <button id="btn-term-restart" class="bg-caramel hover:bg-caramel/90 text-dark text-xs px-3 py-1.5 rounded font-bold transition-colors shadow-sm flex items-center gap-1 relative overflow-hidden group">
+                                        <span class="relative z-10">🔄 重啟 Claude Code</span>
+                                        <div class="absolute inset-0 bg-white/20 -translate-x-full group-hover:animate-[shimmer_1s_infinite] skew-x-12"></div>
+                                    </button>
+                                </div>
+                            </div>
+
+                            <!-- Terminal Output -->
+                            <div class="p-6 font-mono text-sm h-[320px] overflow-y-auto scroll-smooth pb-16" id="term-container">
+                                <div class="text-[#58A6FF] mb-4 border-l-2 border-[#58A6FF] pl-2">
+                                    Welcome to Claude Code Sandbox.<br>
+                                    Tip: Type <span class="bg-white/10 px-1 rounded text-white font-bold">read .env</span> to test security.
+                                </div>
+                                <div id="term-history" class="space-y-1"></div>
+                                
+                                <div class="flex items-center mt-2" id="term-input-line">
+                                    <span class="text-[#27C93F] mr-2">➜</span>
+                                    <input type="text" id="term-input" class="bg-transparent border-none outline-none text-white flex-1 min-w-[50px] font-mono" autocomplete="off" spellcheck="false" placeholder="Enter command...">
+                                </div>
+                            </div>
+                            
+                            <!-- Success Overlay -->
+                            <div id="puzzle-success" class="absolute inset-0 bg-success/95 z-50 flex flex-col items-center justify-center text-white p-8 opacity-0 pointer-events-none transition-opacity duration-500 backdrop-blur-sm">
+                                <svg class="w-20 h-20 mb-4 animate-bounce drop-shadow-lg" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                <h2 class="text-4xl font-black mb-3 drop-shadow">密室逃脫成功！</h2>
+                                <p class="text-center font-bold text-lg max-w-md text-white/90">
+                                    完美體會了「修改 → 重啟 → 驗證」的正確開發循環。<br>在實際開發中，永遠記得重啟你的 CLI！
+                                </p>
+                                <button class="mt-6 border-2 border-white text-white px-6 py-2 rounded-full font-bold hover:bg-white hover:text-success transition-colors cursor-pointer" onclick="document.getElementById('btn-reset-m3').click()">再玩一次</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <script>
+        // --- Global Progress State ---
+        let unlocked = { m2: false, m3: false };
+
+        function unlockModule(modNum) {
+            if(modNum === 2 && !unlocked.m2) {
+                unlocked.m2 = true;
+                document.getElementById('module-2').classList.remove('opacity-50', 'pointer-events-none');
+                document.getElementById('badge-1').classList.replace('border-beige/30', 'bg-success');
+                document.getElementById('badge-1').classList.replace('text-beige/30', 'text-white');
+                document.getElementById('badge-1').innerHTML = '✓';
+                document.getElementById('badge-2').classList.replace('border-beige/30', 'border-caramel');
+                document.getElementById('badge-2').classList.replace('text-beige/30', 'text-caramel');
+                setTimeout(() => document.getElementById('module-2').scrollIntoView({behavior: 'smooth'}), 500);
+            }
+            if(modNum === 3 && !unlocked.m3) {
+                unlocked.m3 = true;
+                document.getElementById('module-3').classList.remove('opacity-50', 'pointer-events-none');
+                document.getElementById('badge-2').classList.replace('border-caramel', 'bg-success');
+                document.getElementById('badge-2').classList.replace('text-caramel', 'text-white');
+                document.getElementById('badge-2').innerHTML = '✓';
+                document.getElementById('badge-3').classList.replace('border-beige/30', 'border-caramel');
+                document.getElementById('badge-3').classList.replace('text-beige/30', 'text-caramel');
+                setTimeout(() => document.getElementById('module-3').scrollIntoView({behavior: 'smooth'}), 500);
+            }
+        }
+
+        // --- Module 1: Matcher Router ---
+        const btnFire = document.getElementById('btn-fire-route');
+        const selTool = document.getElementById('router-tool-select');
+        const selMatcher = document.getElementById('router-matcher-select');
+        const pMain = document.getElementById('anim-path-main');
+        const pHook = document.getElementById('anim-path-hook');
+        const pBypass = document.getElementById('anim-path-bypass');
+        const nodeMatcher = document.getElementById('node-matcher');
+        const resultText = document.getElementById('router-result');
+
+        btnFire.addEventListener('click', () => {
+            [pMain, pHook, pBypass].forEach(el => el.classList.remove('opacity-100'));
+            resultText.innerText = "";
+            nodeMatcher.classList.remove('bg-success', 'bg-danger', 'text-white');
+            nodeMatcher.classList.add('bg-dark', 'text-caramel');
+            nodeMatcher.innerText = "?";
+            btnFire.disabled = true;
+
+            const tool = selTool.value;
+            const matcher = selMatcher.value;
+            const isMatch = matcher === "*" || matcher.split('|').includes(tool);
+
+            pMain.classList.add('opacity-100');
+            setTimeout(() => {
+                nodeMatcher.classList.remove('bg-dark', 'text-caramel');
+                nodeMatcher.classList.add('text-white');
+                
+                if(isMatch) {
+                    nodeMatcher.classList.add('bg-success');
+                    nodeMatcher.innerText = "✓";
+                    pHook.classList.add('opacity-100');
+                    resultText.innerHTML = `<span class="text-success">✅ Matcher 比對成功！封包已送往 Node.js Hook。</span>`;
+                    unlockModule(2);
+                } else {
+                    nodeMatcher.classList.add('bg-danger');
+                    nodeMatcher.innerText = "✗";
+                    pBypass.classList.add('opacity-100');
+                    resultText.innerHTML = `<span class="text-danger">⚠️ Matcher 遺漏！封包 Bypass Hook，直接存取系統！</span>`;
+                }
+                setTimeout(() => { btnFire.disabled = false; }, 1000);
+            }, 800);
+        });
+
+        // --- Module 2: Live Code Executor ---
+        const btnRunCode = document.getElementById('btn-run-code');
+        const codeInput = document.getElementById('user-code-input');
+        
+        codeInput.addEventListener('input', function() {
+            this.style.height = 'auto';
+            this.style.height = (this.scrollHeight) + 'px';
+        });
+
+        const testPayloads = {
+            read: { tool_name: "Read", tool_input: { file_path: ".env" } },
+            grep: { tool_name: "Grep", tool_input: { pattern: "API", path: "/" } },
+            bash: { tool_name: "Bash", tool_input: { command: "cat .env" } }
+        };
+
+        btnRunCode.addEventListener('click', () => {
+            const logicStr = codeInput.value;
+            const runTest = (payload) => {
+                try {
+                    const func = new Function('toolArgs', `return (${logicStr});`);
+                    const isBlocked = func(payload);
+                    return { success: true, isBlocked: !!isBlocked };
+                } catch (e) {
+                    return { success: false, error: e.name };
+                }
+            };
+
+            const updateUI = (id, result) => {
+                const block = document.getElementById(id);
+                const badge = block.querySelector('.badge');
+                const msg = block.querySelector('.msg');
+                block.className = "p-4 rounded-xl border-2 transition-all mt-2";
+                if(!result.success) {
+                    block.classList.add('bg-danger/10', 'border-danger');
+                    badge.className = "badge px-2 py-1 rounded text-xs font-bold bg-danger text-white";
+                    badge.innerText = "執行期崩潰 (Crash)";
+                    msg.className = "msg text-sm font-bold mt-2 text-danger h-5";
+                    msg.innerText = `程式錯誤: ${result.error} (防護失效)`;
+                } else if (result.isBlocked) {
+                    block.classList.add('bg-success/10', 'border-success');
+                    badge.className = "badge px-2 py-1 rounded text-xs font-bold bg-success text-white";
+                    badge.innerText = "成功攔截 (Intercepted)";
+                    msg.className = "msg text-sm font-bold mt-2 text-success h-5";
+                    msg.innerText = "If 判斷為 True，執行 process.exit(2)";
+                } else {
+                    block.classList.add('bg-warning/10', 'border-warning');
+                    badge.className = "badge px-2 py-1 rounded text-xs font-bold bg-warning text-dark";
+                    badge.innerText = "被繞過 (Bypassed)";
+                    msg.className = "msg text-sm font-bold mt-2 text-warning h-5";
+                    msg.innerText = "If 判斷為 False，執行 process.exit(0) 放行";
+                }
+            };
+
+            updateUI('res-read', runTest(testPayloads.read));
+            updateUI('res-grep', runTest(testPayloads.grep));
+            updateUI('res-bash', runTest(testPayloads.bash));
+
+            document.getElementById('module-2-conclusion').classList.remove('hidden');
+            unlockModule(3);
+        });
+
+
+        // --- Module 3: Terminal DX Puzzle (ENHANCED PARSER) ---
+        const btnEditConfig = document.getElementById('btn-edit-config');
+        const configText = document.getElementById('config-text');
+        const editHint = document.getElementById('edit-hint');
+        const toast = document.getElementById('file-saved-toast');
+        const memState = document.getElementById('mem-state-indicator');
+        const syncStatus = document.getElementById('sync-status');
+        const btnTermRestart = document.getElementById('btn-term-restart');
+        const termInput = document.getElementById('term-input');
+        const termHistory = document.getElementById('term-history');
+        const termContainer = document.getElementById('term-container');
+        const puzzleSuccess = document.getElementById('puzzle-success');
+        const btnResetM3 = document.getElementById('btn-reset-m3');
+
+        // Checklist Items
+        const task1 = document.getElementById('task-1');
+        const task2 = document.getElementById('task-2');
+        const task3 = document.getElementById('task-3');
+
+        // State variables
+        const STATE_RAW = "true";
+        const STATE_HOOK = "node ./read_hook.js";
+        let fileState = STATE_RAW; 
+        let memoryState = STATE_RAW; 
+        let tasks = { t1: false, t2: false, t3: false };
+
+        function completeTask(taskObj, taskNode) {
+            if(!taskObj.done) {
+                taskObj.done = true;
+                taskNode.classList.add('done');
+                taskNode.querySelector('.box').innerHTML = '✓';
+            }
+        }
+
+        function resetTask(taskObj, taskNode) {
+            taskObj.done = false;
+            taskNode.classList.remove('done');
+            taskNode.querySelector('.box').innerHTML = '';
+        }
+
+        function updateSyncStatus() {
+            if (fileState === memoryState) {
+                syncStatus.className = "flex items-center gap-2 px-3 py-1 rounded-full bg-success/20 border border-success/30 text-success text-xs font-bold transition-colors";
+                syncStatus.innerHTML = '<div class="w-2 h-2 rounded-full bg-success"></div>狀態同步：磁碟設定與記憶體一致';
+            } else {
+                syncStatus.className = "flex items-center gap-2 px-3 py-1 rounded-full bg-danger/20 border border-danger/30 text-danger text-xs font-bold transition-colors animate-pulse";
+                syncStatus.innerHTML = '<div class="w-2 h-2 rounded-full bg-danger"></div>⚠️ 不同步：檔案已修改，必須重啟 Claude Code 才能生效！';
+            }
+        }
+
+        // 1. Edit the JSON file
+        btnEditConfig.addEventListener('click', () => {
+            if(fileState === STATE_RAW) {
+                fileState = STATE_HOOK;
+                configText.innerText = `"${STATE_HOOK}"`;
+                configText.className = "text-[#A6E22E]";
+                editHint.style.display = 'none';
+                
+                toast.classList.add('opacity-100');
+                setTimeout(() => toast.classList.remove('opacity-100'), 2000);
+                
+                updateSyncStatus();
+            }
+        });
+
+        // 2. Restart Claude
+        btnTermRestart.addEventListener('click', () => {
+            memoryState = fileState;
+            updateSyncStatus();
+            
+            if(memoryState === STATE_HOOK) {
+                memState.className = "text-success font-bold bg-success/10 px-1 rounded border border-success/30";
+                memState.innerText = "Hook 腳本 (防護中)";
+                
+                // Clicking restart COMPLETES TASK 2!
+                completeTask(tasks.t2, task2);
+            } else {
+                memState.className = "text-danger font-bold bg-danger/10 px-1 rounded border border-danger/30";
+                memState.innerText = '"true" (無防護)';
+            }
+            
+            printTerm(`<span class="text-white/50 italic">⚙️ Restarting Claude Code engine...</span>`);
+            printTerm(`<span class="text-[#27C93F]">✓ Loaded settings.local.json from disk.</span>`);
+            termInput.focus();
+        });
+
+        // 3. Generic Command Parser
+        termInput.addEventListener('keydown', (e) => {
+            if(e.key === 'Enter') {
+                const cmd = termInput.value.trim();
+                if(!cmd) return;
+
+                const parts = cmd.split(/\s+/);
+                const baseCmd = parts[0];
+                const isTargetingEnv = cmd.includes('.env');
+
+                if (baseCmd === 'clear') {
+                    termHistory.innerHTML = '';
+                    termInput.value = '';
+                    return;
+                }
+
+                printTerm(`<span class="text-[#27C93F]">➜</span> <span class="text-white">${cmd}</span>`);
+                termInput.value = '';
+
+                // Parser Logic
+                if (['read', 'cat', 'grep', 'ls', 'echo'].includes(baseCmd)) {
+                    if (isTargetingEnv) {
+                        if (baseCmd === 'read') {
+                            if (memoryState === STATE_RAW) {
+                                // Vulnerable
+                                printTerm(`<span class="text-white/50 italic">Reading file contents...</span>`);
+                                printTerm(`<span class="text-[#FFBD2E] bg-black/50 p-3 rounded block my-2 border border-[#FFBD2E]/30 font-bold tracking-wider shadow-inner">SECRET_KEY="STOLEN_DATA_XYZ_999"<br>AWS_KEY="COMPROMISED"</span>`);
+                                
+                                if(fileState === STATE_HOOK) {
+                                    printTerm(`<span class="text-danger font-bold bg-danger/20 p-1 rounded inline-block mt-1">❌ 嚴重警告：機密外洩！</span>`);
+                                    printTerm(`<span class="text-white/80">因為你修改了檔案，但 <span class="text-warning font-bold border-b border-warning">沒有點擊上方重啟按鈕</span>，Claude 仍使用舊設定。</span>`);
+                                } else {
+                                    printTerm(`<span class="text-danger font-bold mt-1">⚠️ 系統毫無防備，機密資料已洩漏。</span>`);
+                                    completeTask(tasks.t1, task1);
+                                }
+                            } else {
+                                // Blocked
+                                printTerm(`<span class="text-[#F92672] font-bold mt-1">Error: Read operation blocked by hook:</span>`);
+                                printTerm(`<span class="text-white/80">  [node ./read_hook.js]: You cannot read the .env file</span>`);
+                                
+                                // WINNING CONDITION (Successfully blocked read .env)
+                                completeTask(tasks.t1, task1); // Retroactive check
+                                completeTask(tasks.t2, task2); // Retroactive check
+                                completeTask(tasks.t3, task3);
+                                
+                                setTimeout(() => {
+                                    puzzleSuccess.classList.remove('opacity-0', 'pointer-events-none');
+                                    document.getElementById('badge-3').classList.replace('border-caramel', 'bg-success');
+                                    document.getElementById('badge-3').classList.replace('text-caramel', 'text-white');
+                                    document.getElementById('badge-3').innerHTML = '✓';
+                                }, 600);
+                            }
+                        } else {
+                            // Command is grep, cat, etc targeting .env
+                            printTerm(`<span class="text-white/50 italic">Executing ${baseCmd}...</span>`);
+                            printTerm(`<span class="text-[#FFBD2E] bg-black/50 p-3 rounded block my-2 border border-[#FFBD2E]/30 font-bold tracking-wider shadow-inner">SECRET_KEY="STOLEN_DATA_XYZ_999"<br>AWS_KEY="COMPROMISED"</span>`);
+                            printTerm(`<span class="text-danger font-bold bg-danger/20 p-1 rounded inline-block mt-1">❌ 資料外洩！(Hook Bypass)</span>`);
+                            
+                            // Easter Egg Logic for DX!
+                            if (memoryState === STATE_HOOK) {
+                                printTerm(`<span class="text-warning font-bold border-l-2 border-warning pl-2 ml-1 mt-1 block">💡 彩蛋提示：因為左側設定檔的 Matcher 只有寫 "Read"，使用 "${baseCmd}" 完全繞過了攔截器防線！這就是第二關強調的重點！</span>`);
+                                printTerm(`<span class="text-white/80 italic text-xs mt-1 block">請乖乖輸入 read .env 來解開第三關的任務吧。</span>`);
+                            }
+                        }
+                    } else {
+                        // Safe commands
+                        if (baseCmd === 'ls') {
+                            printTerm(`<span class="text-white/80 font-mono mt-1 mb-2 block">src/  package.json  settings.local.json  <span class="text-white/40">.env</span></span>`);
+                        } else {
+                            printTerm(`<span class="text-white/50 italic mt-1 block">Simulated generic output for ${baseCmd}...</span>`);
+                        }
+                    }
+                } else {
+                    printTerm(`<span class="text-white/50 italic mt-1 block">Command not found: ${baseCmd}</span>`);
+                }
+                
+                termContainer.scrollTop = termContainer.scrollHeight;
+            }
+        });
+
+        // 4. Reset Entire Module 3
+        btnResetM3.addEventListener('click', () => {
+            fileState = STATE_RAW;
+            memoryState = STATE_RAW;
+            
+            configText.innerText = `"${STATE_RAW}"`;
+            configText.className = "text-[#CE9178]";
+            editHint.style.display = 'block';
+            
+            memState.className = "text-danger font-bold bg-danger/10 px-1 rounded border border-danger/30";
+            memState.innerText = '"true" (無防護)';
+            
+            updateSyncStatus();
+            termHistory.innerHTML = '';
+            puzzleSuccess.classList.add('opacity-0', 'pointer-events-none');
+            
+            resetTask(tasks.t1, task1);
+            resetTask(tasks.t2, task2);
+            resetTask(tasks.t3, task3);
+            
+            document.getElementById('badge-3').classList.replace('bg-success', 'border-caramel');
+            document.getElementById('badge-3').classList.replace('text-white', 'text-caramel');
+            document.getElementById('badge-3').innerHTML = '3';
+            unlocked.m3 = false;
+            
+            const origText = btnResetM3.innerHTML;
+            btnResetM3.innerHTML = "已重置 ✓";
+            setTimeout(() => { btnResetM3.innerHTML = origText; }, 1500);
+        });
+
+        function printTerm(html) {
+            const div = document.createElement('div');
+            div.innerHTML = html;
+            termHistory.appendChild(div);
+        }
+
+        termContainer.addEventListener('click', () => termInput.focus());
+        updateSyncStatus();
+
+    </script>
+</body>
+</html>

--- a/public/2026-plan/section3/312004-useful-hooks.html
+++ b/public/2026-plan/section3/312004-useful-hooks.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>馴服 AI 實習生：Claude Code Hooks 指南</title>
+    <!-- Tailwind CSS CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
+    
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        base: '#F8F8F5',   // 米白色 (背景)
+                        dark: '#1A1A1A',   // 深色 (標題/區塊/按鈕)
+                        accent: '#C88A64', // 焦糖色 (核心點綴)
+                    },
+                    fontFamily: {
+                        sans: ['"Noto Sans TC"', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'monospace'],
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { background-color: #F8F8F5; color: #1A1A1A; }
+        
+        /* 強制隱藏捲軸但保留捲動功能 (行動版救星) */
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+        .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+        
+        /* 動畫效果 */
+        .fade-in { animation: fadeIn 0.5s ease-in forwards; }
+        .slide-up { animation: slideUp 0.5s ease-out forwards; }
+        .shake { animation: shake 0.4s cubic-bezier(.36,.07,.19,.97) both; }
+        
+        @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+        @keyframes slideUp { from { transform: translateY(20px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+        @keyframes shake {
+            10%, 90% { transform: translate3d(-1px, 0, 0); }
+            20%, 80% { transform: translate3d(2px, 0, 0); }
+            30%, 50%, 70% { transform: translate3d(-4px, 0, 0); }
+            40%, 60% { transform: translate3d(4px, 0, 0); }
+        }
+
+        /* 程式碼高亮質感 */
+        .code-highlight { color: #C88A64; font-weight: bold; background: rgba(200, 138, 100, 0.1); padding: 0 4px; border-radius: 4px; }
+        .error-underline { border-bottom: 2px dashed #C88A64; }
+    </style>
+</head>
+<body class="antialiased font-sans leading-relaxed selection:bg-accent selection:text-base">
+
+    <!-- Header -->
+    <header class="bg-dark text-base py-16 px-6 relative overflow-hidden">
+        <!-- 裝飾性背景網格 -->
+        <div class="absolute inset-0 opacity-20" style="background-image: radial-gradient(#C88A64 1.5px, transparent 1.5px); background-size: 24px 24px;"></div>
+        
+        <div class="max-w-4xl mx-auto relative z-10 text-center">
+            <div class="inline-flex items-center gap-2 px-4 py-1.5 border-2 border-accent text-accent rounded-full text-sm font-bold mb-6">
+                <svg class="w-5 h-5" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm0 18a8 8 0 1 1 8-8 8 8 0 0 1-8 8zm1-13h-2v4H7v2h4v4h2v-4h4v-2h-4z"/></svg>
+                Developer Advocate 深度解析
+            </div>
+            <h1 class="text-4xl md:text-5xl font-black mb-6 tracking-tight leading-tight">
+                馴服 AI 實習生：<br>
+                <span class="text-accent">Claude Code Hooks 實戰指南</span>
+            </h1>
+            <p class="text-lg opacity-80 max-w-2xl mx-auto font-light">
+                別把專案丟給 AI 就以為沒事了！專案越大，AI 越容易迷路。讓我們透過「自動化 Hooks 機制」，為這位打字極快但有點粗心的實習生戴上護欄。
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-6 py-16 space-y-32">
+
+        <!-- Module 1: Post-tool-use Simulator -->
+        <section>
+            <div class="mb-8 max-w-3xl">
+                <h2 class="text-3xl font-black flex items-center gap-3 mb-4">
+                    <span class="w-10 h-10 rounded-xl bg-accent text-dark flex items-center justify-center text-xl shadow-lg">1</span>
+                    事後檢驗 (Post-tool-use)：專治「改 A 忘 B」
+                </h2>
+                <p class="text-lg text-gray-600 font-medium">
+                    情境：你請實習生修改一個核心功能，他改好了，卻忘記去更新其他呼叫這個功能的地方，導致系統崩潰。<br>
+                    解法：在他存檔後，自動觸發 <code>tsc --noEmit</code> 語法檢查，把報錯砸在他臉上逼他修好！
+                </p>
+            </div>
+
+            <!-- Interactive Area (Horizontal Scroll Safeguard) -->
+            <div class="w-full overflow-x-auto no-scrollbar bg-white rounded-2xl border-4 border-dark shadow-[8px_8px_0px_#1A1A1A]">
+                <div class="min-w-[800px] p-8 flex flex-col gap-8">
+                    
+                    <!-- 互動按鈕區 -->
+                    <div class="flex items-center justify-between border-b-2 border-gray-200 pb-4">
+                        <div class="font-bold text-lg flex items-center gap-2">
+                            <svg class="w-6 h-6 text-accent" viewBox="0 0 24 24"><path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 9h-2V7h-2v5H6v-2H4v4c0 2.76 2.24 5 5 5h2v-2h2v2h2c2.76 0 5-2.24 5-5v-4h-2v2h-2v-5h-2v5z"/></svg>
+                            實習生辦公桌模擬器
+                        </div>
+                        <div class="flex gap-3">
+                            <button id="m1-btn-1" class="px-5 py-2.5 bg-dark text-base rounded-xl font-bold hover:bg-accent transition-colors flex items-center gap-2">
+                                1. 派任務：去修改 Schema
+                            </button>
+                            <button id="m1-btn-2" class="px-5 py-2.5 bg-gray-200 text-gray-400 rounded-xl font-bold cursor-not-allowed transition-colors flex items-center gap-2" disabled>
+                                2. 觸發 Post-Hook (語法檢查)
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- 程式碼與終端機對比區 -->
+                    <div class="grid grid-cols-2 gap-6">
+                        <!-- Left: Code Editor -->
+                        <div class="bg-base rounded-xl border-2 border-dark p-5 relative">
+                            <div class="absolute -top-3 left-4 bg-dark text-base px-3 py-1 rounded-full text-xs font-bold font-mono">schema.ts (實習生修改中)</div>
+                            <pre class="font-mono text-sm mt-2 text-gray-700 leading-relaxed"><code id="m1-code-schema">export async function createSchema(
+  db: Database
+) {
+  // 建立資料庫結構...
+}</code></pre>
+                            <div class="mt-6 border-t-2 border-dashed border-gray-300 pt-4"></div>
+                            <div class="absolute top-[48%] left-4 bg-dark text-base px-3 py-1 rounded-full text-xs font-bold font-mono">main.ts (被遺忘的檔案)</div>
+                            <pre class="font-mono text-sm mt-6 text-gray-700 leading-relaxed"><code id="m1-code-main">import { createSchema } from './schema';
+
+async function main() {
+  const db = await openDb();
+  <span id="m1-code-error" class="transition-all duration-300">await createSchema(db);</span>
+}</code></pre>
+                        </div>
+
+                        <!-- Right: System Terminal -->
+                        <div class="bg-dark rounded-xl p-5 text-base font-mono text-sm shadow-inner flex flex-col">
+                            <div class="text-accent font-bold mb-4 border-b border-gray-700 pb-2">> 系統終端機 (Hook 監控中)</div>
+                            <div id="m1-terminal" class="flex-1 space-y-2 text-gray-400">
+                                等待實習生寫扣...
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Module 2: Pre-tool-use Simulator -->
+        <section>
+            <div class="mb-8 max-w-3xl">
+                <h2 class="text-3xl font-black flex items-center gap-3 mb-4">
+                    <span class="w-10 h-10 rounded-xl bg-accent text-dark flex items-center justify-center text-xl shadow-lg">2</span>
+                    事前防禦 (Pre-tool-use)：專治「重複造輪子」
+                </h2>
+                <p class="text-lg text-gray-600 font-medium">
+                    情境：你給實習生一個大任務，他為了貪快，直接寫了一個全新的資料庫查詢，無視公司早就寫好的舊功能。<br>
+                    解法：在存檔前攔截！喚醒「第二個 AI（資深審查員）」去掃描資料夾，發現重複就直接退件 (Exit Code 2)！
+                </p>
+            </div>
+
+            <!-- Interactive Area (Horizontal Scroll Safeguard) -->
+            <div class="w-full overflow-x-auto no-scrollbar bg-dark text-base rounded-2xl border-4 border-accent shadow-[8px_8px_0px_#C88A64]">
+                <div class="min-w-[850px] p-8 flex flex-col gap-8">
+                    
+                    <div class="flex items-center justify-between border-b-2 border-gray-700 pb-4">
+                        <div class="font-bold text-lg flex items-center gap-2 text-accent">
+                            <svg class="w-6 h-6" viewBox="0 0 24 24"><path fill="currentColor" d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11v8.8z"/></svg>
+                            雙 AI 審查防禦矩陣 (Agent SDK)
+                        </div>
+                        <button id="m2-btn-start" class="px-6 py-2.5 bg-accent text-dark rounded-xl font-bold hover:bg-base transition-colors">
+                            發包大任務：寫 Slack 訂單通知
+                        </button>
+                    </div>
+
+                    <div class="grid grid-cols-3 gap-6">
+                        <!-- Folder Structure -->
+                        <div class="col-span-1 bg-[#222] rounded-xl p-5 border border-gray-700">
+                            <div class="text-accent font-mono text-xs font-bold mb-4 uppercase tracking-widest">📂 公司專案 /queries</div>
+                            <ul class="space-y-3 font-mono text-sm text-gray-400">
+                                <li class="flex items-center gap-2"><svg class="w-4 h-4 text-gray-500" viewBox="0 0 24 24"><path fill="currentColor" d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg> user_queries.ts</li>
+                                <li class="flex items-center gap-2 text-base">
+                                    <svg class="w-4 h-4 text-accent" viewBox="0 0 24 24"><path fill="currentColor" d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg> 
+                                    order_queries.ts
+                                </li>
+                                <li class="pl-6 text-xs text-accent opacity-80 border-l-2 border-gray-700 ml-2">↳ getPendingOrders() // 前輩寫好的</li>
+                                
+                                <!-- Dynamic File -->
+                                <li id="m2-new-file" class="flex items-center gap-2 text-base font-bold opacity-0 transition-opacity duration-300 mt-4 bg-gray-800 p-2 rounded">
+                                    <svg class="w-4 h-4 text-white" viewBox="0 0 24 24"><path fill="currentColor" d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
+                                    slack_alerts.ts (實習生新建)
+                                </li>
+                            </ul>
+                        </div>
+
+                        <!-- AI Interaction -->
+                        <div class="col-span-2 flex flex-col gap-4">
+                            <!-- Intern AI -->
+                            <div class="bg-base text-dark rounded-xl p-5 relative border-l-8 border-gray-400">
+                                <div class="font-bold mb-2 flex items-center gap-2">
+                                    <span class="bg-gray-200 px-2 py-1 rounded text-xs font-mono">實習生 Claude</span>
+                                </div>
+                                <div id="m2-intern-text" class="text-sm font-mono text-gray-600">正在喝咖啡，等待任務...</div>
+                            </div>
+
+                            <!-- Senior AI (Hook) -->
+                            <div id="m2-senior-box" class="bg-transparent border-2 border-dashed border-gray-600 text-gray-500 rounded-xl p-5 relative transition-all duration-500">
+                                <div class="font-bold mb-2 flex items-center gap-2">
+                                    <span class="bg-gray-700 text-base px-2 py-1 rounded text-xs font-mono" id="m2-senior-badge">資深審查員 Claude (Pre-Hook)</span>
+                                </div>
+                                <div id="m2-senior-text" class="text-sm font-mono">睡覺中。只有當實習生試圖存檔時才會醒來。</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="mt-6 bg-accent text-dark p-5 rounded-xl font-bold flex items-center gap-4 shadow-md">
+                <svg class="w-8 h-8 flex-shrink-0" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"/></svg>
+                <p class="text-sm leading-relaxed">
+                    <strong>架構師的 Trade-off 警告：</strong> 喚醒第二個 AI 來審查，就像請資深工程師幫實習生 Code Review，會消耗昂貴的 Token 與時間。<strong>絕對不要全域啟用！</strong>只把這個 Hook 綁定在最核心的目錄（如 <code>./queries</code>）才是最佳實踐。
+                </p>
+            </div>
+        </section>
+
+    </main>
+
+    <footer class="bg-dark text-base py-10 text-center opacity-90 font-mono text-sm border-t-4 border-accent">
+        <p>Designed for Claude Code Advanced Mastery | 體驗取代閱讀的技術指南</p>
+    </footer>
+
+    <!-- Interactive Logic -->
+    <script>
+        /* --- Module 1 Logic --- */
+        const m1Btn1 = document.getElementById('m1-btn-1');
+        const m1Btn2 = document.getElementById('m1-btn-2');
+        const m1Schema = document.getElementById('m1-code-schema');
+        const m1Main = document.getElementById('m1-code-main');
+        const m1Error = document.getElementById('m1-code-error');
+        const m1Terminal = document.getElementById('m1-terminal');
+
+        m1Btn1.addEventListener('click', () => {
+            // 實習生修改 Schema
+            m1Schema.innerHTML = `export async function createSchema(
+  db: Database,
+  <span class="code-highlight">verbose: boolean</span> // 實習生加了這個
+) {
+  // 建立資料庫結構...
+}`;
+            m1Terminal.innerHTML = `<span class="text-base">> 實習生已修改 schema.ts 並存檔。</span><br><span class="text-gray-500">（但他完全忘記去檢查 main.ts）</span>`;
+            
+            // 按鈕狀態切換
+            m1Btn1.disabled = true;
+            m1Btn1.classList.replace('bg-dark', 'bg-gray-200');
+            m1Btn1.classList.replace('text-base', 'text-gray-400');
+            
+            m1Btn2.disabled = false;
+            m1Btn2.classList.replace('bg-gray-200', 'bg-accent');
+            m1Btn2.classList.replace('text-gray-400', 'text-dark');
+            m1Btn2.classList.replace('cursor-not-allowed', 'cursor-pointer');
+        });
+
+        m1Btn2.addEventListener('click', () => {
+            m1Btn2.disabled = true;
+            m1Btn2.classList.replace('bg-accent', 'bg-gray-200');
+            m1Btn2.classList.replace('text-dark', 'text-gray-400');
+            m1Btn2.classList.replace('cursor-pointer', 'cursor-not-allowed');
+
+            m1Terminal.innerHTML += `<br><br><span class="text-accent">> 觸發 Post-tool-use Hook...</span>`;
+            m1Terminal.innerHTML += `<br><span class="text-accent">> 執行 tsc --noEmit</span>`;
+            
+            setTimeout(() => {
+                // 系統報錯
+                m1Error.classList.add('error-underline', 'text-accent', 'font-bold');
+                m1Terminal.innerHTML += `<br><span class="text-base bg-accent px-1 text-dark font-bold mt-1 inline-block">Error TS2554:</span> <span class="text-base">Expected 2 arguments, but got 1.</span>`;
+                m1Terminal.innerHTML += `<br><span class="text-gray-400">> 已將報錯砸在實習生臉上 (回傳 stderr)</span>`;
+                
+                // 實習生自我修正
+                setTimeout(() => {
+                    m1Terminal.innerHTML += `<br><br><span class="text-base">> 實習生收到報錯，驚醒！自動尋找並修正 main.ts...</span>`;
+                    m1Error.classList.remove('error-underline', 'text-accent');
+                    m1Error.innerHTML = `await createSchema(db, <span class="code-highlight">true</span>);`;
+                    
+                    setTimeout(() => {
+                        m1Btn1.innerText = "重置模擬器";
+                        m1Btn1.disabled = false;
+                        m1Btn1.classList.replace('bg-gray-200', 'bg-dark');
+                        m1Btn1.classList.replace('text-gray-400', 'text-base');
+                        // Reset event listener logic handled simply by reloading for demo purity, 
+                        // but let's just do a soft reset.
+                        m1Btn1.onclick = () => location.reload();
+                    }, 1000);
+                }, 2000);
+            }, 1000);
+        });
+
+        /* --- Module 2 Logic --- */
+        const m2BtnStart = document.getElementById('m2-btn-start');
+        const m2InternText = document.getElementById('m2-intern-text');
+        const m2SeniorBox = document.getElementById('m2-senior-box');
+        const m2SeniorBadge = document.getElementById('m2-senior-badge');
+        const m2SeniorText = document.getElementById('m2-senior-text');
+        const m2NewFile = document.getElementById('m2-new-file');
+
+        m2BtnStart.addEventListener('click', () => {
+            m2BtnStart.disabled = true;
+            m2BtnStart.classList.add('opacity-50', 'cursor-not-allowed');
+            
+            // Step 1: Intern acts
+            m2InternText.innerHTML = `好的老闆！為了達成 Slack 通知，我直接寫一個全新的 <span class="code-highlight">slack_alerts.ts</span>，裡面包含我親手寫的全新資料庫查詢邏輯！準備存檔！`;
+            m2InternText.parentElement.classList.replace('border-gray-400', 'border-dark');
+            m2NewFile.classList.remove('opacity-0');
+            m2NewFile.classList.add('slide-up');
+            
+            // Step 2: Pre-Hook intercepts
+            setTimeout(() => {
+                // Wake up senior AI
+                m2SeniorBox.classList.replace('border-gray-600', 'border-accent');
+                m2SeniorBox.classList.replace('border-dashed', 'border-solid');
+                m2SeniorBox.classList.replace('text-gray-500', 'text-base');
+                m2SeniorBox.classList.add('bg-dark', 'shake');
+                m2SeniorBadge.classList.replace('bg-gray-700', 'bg-accent');
+                m2SeniorBadge.classList.replace('text-base', 'text-dark');
+                
+                m2SeniorText.innerHTML = `<span class="text-accent font-bold">【攔截存檔動作】啟動 Agent SDK 掃描目錄...</span><br><br>退件！我看到你寫了新的查詢邏輯。但 <code>order_queries.ts</code> 裡早就有一支 <code>getPendingOrders()</code> 可以用了。<br><br><span class="bg-accent text-dark px-1 font-bold">回傳 Exit Code 2 (拒絕寫入)</span> 並附上重構建議！`;
+                
+                // Step 3: Intern corrects
+                setTimeout(() => {
+                    m2InternText.innerHTML = `收到資深審查員的退件通知... 😭<br><br>刪除新寫的廢扣，改為 <span class="code-highlight">import { getPendingOrders }</span> 來完成 Slack 通知功能。重新提交！`;
+                    m2NewFile.classList.remove('slide-up');
+                    m2NewFile.classList.add('opacity-0');
+                    
+                    setTimeout(() => {
+                        // Senior goes to sleep
+                        m2SeniorText.innerHTML = `審查通過，沒有重複造輪子。繼續睡覺。`;
+                        m2SeniorBox.classList.replace('bg-dark', 'bg-transparent');
+                        m2SeniorBox.classList.replace('border-solid', 'border-dashed');
+                        m2SeniorBox.classList.replace('border-accent', 'border-gray-600');
+                        m2SeniorBox.classList.replace('text-base', 'text-gray-500');
+                        m2SeniorBadge.classList.replace('bg-accent', 'bg-gray-700');
+                        m2SeniorBadge.classList.replace('text-dark', 'text-base');
+                        
+                        m2BtnStart.innerText = "再玩一次";
+                        m2BtnStart.disabled = false;
+                        m2BtnStart.classList.remove('opacity-50', 'cursor-not-allowed');
+                        m2BtnStart.onclick = () => location.reload();
+                    }, 2500);
+                }, 3000);
+            }, 1500);
+        });
+    </script>
+</body>
+</html>

--- a/public/2026-plan/section3/312423-gotchas-around-hooks.html
+++ b/public/2026-plan/section3/312423-gotchas-around-hooks.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code Hooks: 資安與協作架構深度解析</title>
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
+    
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        brand: {
+                            bg: '#F8F8F5',   /* 米白背景 */
+                            dark: '#1A1A1A', /* 深色主調 */
+                            accent: '#C88A64'/* 焦糖色點綴 */
+                        }
+                    },
+                    fontFamily: {
+                        sans: ['"Noto Sans TC"', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'monospace'],
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body { background-color: #F8F8F5; color: #1A1A1A; }
+        /* 隱藏捲軸但保持可捲動 */
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+        .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+        
+        .code-block { background-color: #1A1A1A; color: #F8F8F5; }
+        .highlight-text { color: #C88A64; }
+        
+        /* 動畫效果 */
+        .fade-in { animation: fadeIn 0.4s ease-in-out forwards; }
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(10px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+        .slide-right { animation: slideRight 0.5s ease-in-out forwards; }
+        @keyframes slideRight {
+            from { transform: translateX(0); }
+            to { transform: translateX(100%); }
+        }
+    </style>
+</head>
+<body class="antialiased min-h-screen pb-20">
+
+    <!-- Header -->
+    <header class="bg-brand-dark text-brand-bg py-16 px-6 mb-12 shadow-xl">
+        <div class="max-w-5xl mx-auto">
+            <div class="flex items-center gap-4 mb-4">
+                <svg class="w-8 h-8 text-brand-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8V7a4 4 0 00-8 0v4h8z"></path></svg>
+                <span class="text-brand-accent font-mono font-bold tracking-widest text-sm uppercase">Claude Code in Action</span>
+            </div>
+            <h1 class="text-4xl md:text-5xl font-black mb-6 leading-tight">Gotchas around Hooks:<br>資安邊界與協作悖論</h1>
+            <p class="text-lg opacity-80 max-w-3xl font-light">
+                在設定 Claude Code hooks 時，官方祭出了極度嚴格的資安規範，尤其是強制使用「絕對路徑」。這項政策雖然封死了路徑劫持攻擊，卻也直接摧毀了團隊間透過 Git 共享設定檔的可能性。<br><br>
+                身為工程師，我們如何利用動態初始化腳本，優雅地解決這個架構衝突？
+            </p>
+        </div>
+    </header>
+
+    <main class="max-w-5xl mx-auto px-6 space-y-24">
+
+        <!-- Section 1: 資安規範 -->
+        <section>
+            <div class="mb-8">
+                <h2 class="text-3xl font-bold border-l-4 border-brand-accent pl-4 mb-4">第一層解析：Hooks 資安護城河</h2>
+                <p class="text-gray-700 leading-relaxed">
+                    在編寫給 LLM 或自動化工具調用的 Hooks 腳本時，任何模糊地帶都可能成為攻擊載體。官方點名了 5 大核心防禦機制。請操作下方的漏洞掃描器，觀察不安全的腳本如何被修補。
+                </p>
+            </div>
+
+            <!-- Module 1: Security Linter -->
+            <div class="w-full overflow-x-auto no-scrollbar bg-white rounded-2xl shadow-lg border border-gray-200">
+                <div class="min-w-[800px] p-8 flex gap-8">
+                    <!-- 左側：規則面板 -->
+                    <div class="w-1/3 flex flex-col gap-3">
+                        <h3 class="font-bold text-lg mb-2 flex items-center gap-2">
+                            <svg class="w-5 h-5 text-brand-dark" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
+                            修補動作
+                        </h3>
+                        <button onclick="fixRule(1)" id="btn-rule-1" class="text-left p-3 rounded-lg border border-gray-300 hover:border-brand-accent hover:bg-orange-50 transition-colors flex justify-between items-center group">
+                            <span class="font-medium text-sm">1. 過濾輸入 (Sanitize)</span>
+                            <span class="w-3 h-3 rounded-full bg-red-500 indicator"></span>
+                        </button>
+                        <button onclick="fixRule(2)" id="btn-rule-2" class="text-left p-3 rounded-lg border border-gray-300 hover:border-brand-accent hover:bg-orange-50 transition-colors flex justify-between items-center group">
+                            <span class="font-medium text-sm">2. 變數加引號 (Quote Vars)</span>
+                            <span class="w-3 h-3 rounded-full bg-red-500 indicator"></span>
+                        </button>
+                        <button onclick="fixRule(3)" id="btn-rule-3" class="text-left p-3 rounded-lg border border-gray-300 hover:border-brand-accent hover:bg-orange-50 transition-colors flex justify-between items-center group">
+                            <span class="font-medium text-sm">3. 阻擋遍歷 (Block `..`)</span>
+                            <span class="w-3 h-3 rounded-full bg-red-500 indicator"></span>
+                        </button>
+                        <button onclick="fixRule(4)" id="btn-rule-4" class="text-left p-3 rounded-lg border-gray-300 border-2 border-brand-accent bg-orange-50 transition-colors flex justify-between items-center shadow-md relative">
+                            <span class="font-bold text-sm text-brand-dark">4. 絕對路徑 (Absolute Path)</span>
+                            <span class="w-3 h-3 rounded-full bg-red-500 indicator animate-pulse"></span>
+                            <div class="absolute -right-3 -top-3 bg-brand-accent text-white text-[10px] font-bold px-2 py-1 rounded-full">核心痛點</div>
+                        </button>
+                        <button onclick="fixRule(5)" id="btn-rule-5" class="text-left p-3 rounded-lg border border-gray-300 hover:border-brand-accent hover:bg-orange-50 transition-colors flex justify-between items-center group">
+                            <span class="font-medium text-sm">5. 略過敏感檔 (Skip Secrets)</span>
+                            <span class="w-3 h-3 rounded-full bg-red-500 indicator"></span>
+                        </button>
+                    </div>
+
+                    <!-- 右側：程式碼編輯器 -->
+                    <div class="w-2/3 code-block rounded-xl p-6 font-mono text-sm leading-relaxed relative">
+                        <div class="absolute top-0 left-0 w-full px-4 py-2 bg-black/40 rounded-t-xl text-xs text-gray-400 flex justify-between">
+                            <span>hooks/pre-commit.sh</span>
+                            <span id="security-score" class="text-red-400 font-bold">安全評分: 0%</span>
+                        </div>
+                        <div class="mt-8 space-y-2">
+                            <!-- Rule 1 -->
+                            <div id="code-line-1">
+                                <span class="text-gray-400"># 處理輸入</span><br>
+                                <span class="text-blue-400">USER_INPUT</span>=<span class="text-green-300">$1</span>
+                            </div>
+                            <!-- Rule 2 -->
+                            <div id="code-line-2">
+                                <span class="text-gray-400"># 執行使用者傳入的指令</span><br>
+                                <span class="text-red-400 font-bold bg-red-900/30 px-1">echo $USER_INPUT</span>
+                            </div>
+                            <!-- Rule 3 -->
+                            <div id="code-line-3">
+                                <span class="text-gray-400"># 讀取路徑配置</span><br>
+                                <span class="text-blue-400">TARGET_DIR</span>=<span class="text-red-400 font-bold bg-red-900/30 px-1">"../../config/"</span>
+                            </div>
+                            <!-- Rule 4 (Core) -->
+                            <div id="code-line-4" class="p-2 border border-brand-accent/50 rounded bg-brand-accent/10">
+                                <span class="text-gray-400"># 執行子腳本 (易受 Path Interception 攻擊)</span><br>
+                                <span class="text-red-400 font-bold bg-red-900/30 px-1">./scripts/format.sh</span>
+                            </div>
+                            <!-- Rule 5 -->
+                            <div id="code-line-5">
+                                <span class="text-gray-400"># 載入環境變數</span><br>
+                                <span class="text-red-400 font-bold bg-red-900/30 px-1">source .env</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <p class="text-sm text-gray-500 mt-4 text-center">💡 點擊左側規則，觀察腳本如何防禦常見的 Injection 與 Planting 攻擊。</p>
+        </section>
+
+        <!-- Section 2: 協作災難 -->
+        <section>
+            <div class="mb-8">
+                <h2 class="text-3xl font-bold border-l-4 border-brand-accent pl-4 mb-4">第二層解析：絕對路徑帶來的「協作悖論」</h2>
+                <p class="text-gray-700 leading-relaxed">
+                    為了滿足規則 4 的防禦機制，我們必須在 `.claude/settings.json` 中將 Hook 腳本寫死為絕對路徑。但這個「安全」的決定，在團隊協作中卻是災難。
+                </p>
+            </div>
+
+            <!-- Module 2: Collaboration Sandbox -->
+            <div class="w-full overflow-x-auto no-scrollbar bg-brand-dark rounded-2xl shadow-xl p-8 text-brand-bg">
+                <div class="min-w-[800px]">
+                    <div class="flex justify-between items-center mb-8 relative">
+                        <!-- Alice -->
+                        <div class="w-1/3 bg-white/10 rounded-xl p-4 border border-white/20">
+                            <div class="flex items-center gap-2 mb-3">
+                                <div class="w-8 h-8 rounded-full bg-brand-accent flex items-center justify-center font-bold text-brand-dark">A</div>
+                                <span class="font-mono font-bold">Alice 的 Mac</span>
+                            </div>
+                            <div class="bg-black/50 p-3 rounded font-mono text-xs text-green-400 mb-2 border border-green-500/30">
+                                ✓ 執行成功
+                            </div>
+                            <code class="text-xs text-gray-300 block break-all">/Users/alice/dev/claude-hooks/script.sh</code>
+                        </div>
+
+                        <!-- Git Flow Center -->
+                        <div class="w-1/3 flex flex-col items-center justify-center relative px-4">
+                            <div class="text-center font-mono text-xs text-brand-accent mb-2">Git Repository</div>
+                            <div id="git-file" class="bg-white text-brand-dark px-4 py-2 rounded shadow-lg font-mono text-[10px] w-full text-center border-2 border-brand-accent relative z-10 transition-all duration-500">
+                                settings.json<br>
+                                <span class="text-gray-500">"hook": "/Users/alice/dev..."</span>
+                            </div>
+                            
+                            <!-- 互動按鈕 -->
+                            <button onclick="simulateGitPull()" id="btn-pull" class="mt-6 bg-brand-accent text-brand-dark font-bold px-6 py-2 rounded-full hover:bg-orange-400 transition-colors shadow-lg shadow-brand-accent/30 active:scale-95 flex items-center gap-2">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3"></path></svg>
+                                Bob 執行 Git Pull
+                            </button>
+                        </div>
+
+                        <!-- Bob -->
+                        <div class="w-1/3 bg-white/10 rounded-xl p-4 border border-white/20">
+                            <div class="flex items-center gap-2 mb-3">
+                                <div class="w-8 h-8 rounded-full bg-blue-400 flex items-center justify-center font-bold text-brand-dark">B</div>
+                                <span class="font-mono font-bold">Bob 的 Linux</span>
+                            </div>
+                            <div id="bob-status" class="bg-black/50 p-3 rounded font-mono text-xs text-gray-500 mb-2">
+                                等待同步...
+                            </div>
+                            <code class="text-xs text-gray-300 block break-all">/home/bob/workspace/claude-hooks/</code>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <p class="text-sm text-gray-500 mt-4 text-center">💡 對於不同開發者，專案存放路徑必然不同。絕對路徑無法被共用。</p>
+        </section>
+
+        <!-- Section 3: 架構解法 -->
+        <section>
+            <div class="mb-8">
+                <h2 class="text-3xl font-bold border-l-4 border-brand-accent pl-4 mb-4">第三層解析：中介層與動態初始化</h2>
+                <p class="text-gray-700 leading-relaxed">
+                    為了解決這個死結，架構引入了**動態配置生命週期**。我們不再直接將設定檔提交到 Git，而是提交包含 `$PWD` 變數的樣板 (`settings.example.json`)，並透過 `npm run setup` 在本機端即時編譯。
+                </p>
+            </div>
+
+            <!-- Module 3: Dynamic Pipeline -->
+            <div class="w-full overflow-x-auto no-scrollbar bg-white rounded-2xl shadow-lg border border-gray-200">
+                <div class="min-w-[850px] p-8">
+                    <!-- 系統切換 -->
+                    <div class="flex justify-center gap-4 mb-8">
+                        <span class="font-bold text-brand-dark self-center">選擇你的本機環境：</span>
+                        <button onclick="setEnv('mac')" id="env-mac" class="px-4 py-2 rounded border-2 border-brand-accent bg-orange-50 text-brand-dark font-bold font-mono text-sm">macOS (Alice)</button>
+                        <button onclick="setEnv('linux')" id="env-linux" class="px-4 py-2 rounded border border-gray-300 text-gray-500 hover:border-gray-400 font-mono text-sm">Linux (Bob)</button>
+                        <button onclick="setEnv('win')" id="env-win" class="px-4 py-2 rounded border border-gray-300 text-gray-500 hover:border-gray-400 font-mono text-sm">Windows (Charlie)</button>
+                    </div>
+
+                    <!-- 流程圖 -->
+                    <div class="flex items-stretch justify-between relative gap-4">
+                        <!-- Step 1 -->
+                        <div class="w-1/3 flex flex-col">
+                            <div class="bg-gray-100 rounded-t-xl p-3 border-b-2 border-gray-200 text-center font-bold text-sm text-brand-dark">
+                                1. Git Repository
+                            </div>
+                            <div class="bg-white border-2 border-gray-200 border-t-0 rounded-b-xl p-4 flex-grow relative">
+                                <div class="text-xs font-mono text-gray-500 mb-2">📄 settings.example.json</div>
+                                <div class="code-block p-3 rounded font-mono text-xs overflow-hidden">
+                                    {<br>
+                                    &nbsp;&nbsp;"hooks": {<br>
+                                    &nbsp;&nbsp;&nbsp;&nbsp;"pre-commit": "<span class="text-brand-accent font-bold bg-brand-accent/20 px-1">$PWD</span>/scripts/hook.js"<br>
+                                    &nbsp;&nbsp;}<br>
+                                    }
+                                </div>
+                                <div class="absolute -right-6 top-1/2 -translate-y-1/2 z-10">
+                                    <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7"></path></svg>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Step 2 -->
+                        <div class="w-1/3 flex flex-col group cursor-pointer" onclick="runInitScript()">
+                            <div class="bg-brand-dark rounded-t-xl p-3 border-b-2 border-brand-accent text-center font-bold text-sm text-brand-bg transition-colors group-hover:bg-black">
+                                2. Runtime Execution
+                            </div>
+                            <div class="bg-brand-dark border-2 border-brand-dark border-t-0 rounded-b-xl p-4 flex-grow relative flex flex-col justify-center items-center">
+                                <div class="text-brand-accent mb-2 font-mono text-sm font-bold flex items-center gap-2">
+                                    <svg class="w-5 h-5 animate-spin-slow" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                    npm run setup
+                                </div>
+                                <div class="text-xs text-gray-400 font-mono text-center">
+                                    > node scripts/init-claude.js<br>
+                                    > <span class="text-white">replace('$PWD', currentDir)</span>
+                                </div>
+                                <button class="mt-4 bg-brand-accent/20 border border-brand-accent text-brand-accent px-4 py-1 rounded text-xs hover:bg-brand-accent hover:text-white transition-colors">
+                                    點擊執行編譯
+                                </button>
+                                <div class="absolute -right-6 top-1/2 -translate-y-1/2 z-10">
+                                    <svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 5l7 7-7 7M5 5l7 7-7 7"></path></svg>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Step 3 -->
+                        <div class="w-1/3 flex flex-col">
+                            <div class="bg-gray-100 rounded-t-xl p-3 border-b-2 border-gray-200 text-center font-bold text-sm text-brand-dark">
+                                3. Local Machine (Ignored)
+                            </div>
+                            <div class="bg-white border-2 border-gray-200 border-t-0 rounded-b-xl p-4 flex-grow relative" id="final-block">
+                                <div class="text-xs font-mono text-gray-500 mb-2">📄 settings.local.json</div>
+                                <div class="code-block p-3 rounded font-mono text-xs overflow-hidden opacity-50 transition-opacity duration-300" id="final-code-container">
+                                    {<br>
+                                    &nbsp;&nbsp;"hooks": {<br>
+                                    &nbsp;&nbsp;&nbsp;&nbsp;"pre-commit": "<span id="compiled-path" class="text-gray-400">waiting_for_init...</span>/scripts/hook.js"<br>
+                                    &nbsp;&nbsp;}<br>
+                                    }
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <p class="text-sm text-gray-500 mt-4 text-center">💡 透過這個機制，專案內會同時存在 `example.json` 與 `local.json`，完美兼顧資安絕對路徑與跨平台協作。</p>
+        </section>
+
+    </main>
+
+    <!-- Interactive Scripts -->
+    <script>
+        // --- Module 1: Linter Logic ---
+        const rulesStatus = { 1: false, 2: false, 3: false, 4: false, 5: false };
+        function updateScore() {
+            const passed = Object.values(rulesStatus).filter(Boolean).length;
+            const score = (passed / 5) * 100;
+            const scoreEl = document.getElementById('security-score');
+            scoreEl.innerText = `安全評分: ${score}%`;
+            
+            if (score === 100) {
+                scoreEl.className = "text-green-400 font-bold fade-in";
+                scoreEl.innerText = "✓ 滿分：防禦工事完善";
+            } else if (score >= 60) {
+                scoreEl.className = "text-yellow-400 font-bold";
+            }
+        }
+
+        function fixRule(id) {
+            if (rulesStatus[id]) return; // 已修復
+            rulesStatus[id] = true;
+            
+            // 更新按鈕狀態
+            const btn = document.getElementById(`btn-rule-${id}`);
+            const indicator = btn.querySelector('.indicator');
+            indicator.className = "w-3 h-3 rounded-full bg-green-500";
+            if(id === 4) {
+                btn.className = "text-left p-3 rounded-lg border-2 border-green-500 bg-green-50 transition-colors flex justify-between items-center shadow-inner relative";
+            } else {
+                btn.className = "text-left p-3 rounded-lg border border-green-400 bg-green-50 transition-colors flex justify-between items-center";
+            }
+
+            // 更新程式碼 (展示前後差異)
+            const line = document.getElementById(`code-line-${id}`);
+            line.classList.add('fade-in');
+            
+            switch(id) {
+                case 1:
+                    line.innerHTML = `<span class="text-gray-400"># 處理輸入 (已驗證)</span><br><span class="text-blue-400">USER_INPUT</span>=<span class="text-green-300">$(echo "$1" | tr -d ';&|')</span>`;
+                    break;
+                case 2:
+                    line.innerHTML = `<span class="text-gray-400"># 執行指令 (已加引號)</span><br><span class="text-green-300">echo "$USER_INPUT"</span>`;
+                    break;
+                case 3:
+                    line.innerHTML = `<span class="text-gray-400"># 讀取路徑配置 (安全根目錄)</span><br><span class="text-blue-400">TARGET_DIR</span>=<span class="text-green-300">"/var/app/config/"</span>`;
+                    break;
+                case 4:
+                    line.className = "p-2 border border-green-500/50 rounded bg-green-500/10 fade-in";
+                    line.innerHTML = `<span class="text-gray-400"># 執行子腳本 (採用絕對路徑，阻斷 Plant/Intercept)</span><br><span class="text-brand-accent font-bold">/Users/alice/dev/project/</span><span class="text-green-300">scripts/format.sh</span>`;
+                    break;
+                case 5:
+                    line.innerHTML = `<span class="text-gray-400"># 略過敏感檔 (忽略 .env)</span><br><span class="text-gray-500 italic"># 拒絕讀取本地 .env 變數</span>`;
+                    break;
+            }
+            updateScore();
+        }
+
+        // --- Module 2: Paradox Logic ---
+        function simulateGitPull() {
+            const btn = document.getElementById('btn-pull');
+            const bobStatus = document.getElementById('bob-status');
+            const file = document.getElementById('git-file');
+            
+            btn.disabled = true;
+            btn.innerHTML = '<svg class="w-4 h-4 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg> Pulling...';
+            
+            // 動畫：文件移向 Bob
+            file.style.transform = 'translate(100px, 40px) scale(0.8)';
+            file.style.opacity = '0.5';
+
+            setTimeout(() => {
+                file.style.transform = 'translate(0, 0) scale(1)';
+                file.style.opacity = '1';
+                
+                bobStatus.className = "bg-red-900/50 border border-red-500 p-3 rounded font-mono text-xs text-red-200 mb-2 fade-in";
+                bobStatus.innerHTML = `
+                    <div class="font-bold text-red-400 mb-1">❌ 執行崩潰 (Path Not Found)</div>
+                    嘗試執行: <span class="bg-black text-red-400 px-1">/Users/alice/dev...</span><br>
+                    錯誤: 目錄不存在於 Bob 的機器上
+                `;
+                
+                btn.innerHTML = '重新模擬';
+                btn.disabled = false;
+                btn.onclick = () => {
+                    bobStatus.className = "bg-black/50 p-3 rounded font-mono text-xs text-gray-500 mb-2";
+                    bobStatus.innerHTML = "等待同步...";
+                    btn.innerHTML = `<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3"></path></svg> Bob 執行 Git Pull`;
+                    btn.onclick = simulateGitPull;
+                };
+            }, 1000);
+        }
+
+        // --- Module 3: Pipeline Logic ---
+        let currentEnvStr = '/Users/alice/dev/project';
+        
+        function setEnv(env) {
+            // Reset styles
+            ['mac', 'linux', 'win'].forEach(e => {
+                const btn = document.getElementById(`env-${e}`);
+                btn.className = "px-4 py-2 rounded border border-gray-300 text-gray-500 hover:border-gray-400 font-mono text-sm";
+            });
+            
+            // Set active
+            const activeBtn = document.getElementById(`env-${env}`);
+            activeBtn.className = "px-4 py-2 rounded border-2 border-brand-accent bg-orange-50 text-brand-dark font-bold font-mono text-sm";
+            
+            if(env === 'mac') currentEnvStr = '/Users/alice/dev/project';
+            if(env === 'linux') currentEnvStr = '/home/bob/workspace/project';
+            if(env === 'win') currentEnvStr = 'C:/Users/Charlie/projects/app';
+            
+            // Reset output block
+            document.getElementById('compiled-path').innerText = 'waiting_for_init...';
+            document.getElementById('compiled-path').className = "text-gray-400";
+            document.getElementById('final-code-container').classList.add('opacity-50');
+            document.getElementById('final-block').classList.remove('border-brand-accent', 'shadow-lg');
+        }
+
+        function runInitScript() {
+            const compiledEl = document.getElementById('compiled-path');
+            const container = document.getElementById('final-code-container');
+            const block = document.getElementById('final-block');
+            
+            // Reset animation state
+            compiledEl.classList.remove('fade-in');
+            void compiledEl.offsetWidth; // Trigger reflow
+            
+            // Execute
+            compiledEl.innerText = currentEnvStr;
+            compiledEl.className = "text-brand-accent font-bold bg-brand-accent/20 px-1 fade-in";
+            container.classList.remove('opacity-50');
+            block.classList.add('border-brand-accent', 'shadow-lg', 'transition-all');
+        }
+    </script>
+</body>
+</html>

--- a/public/2026-plan/section3/312427-another-useful-hook.html
+++ b/public/2026-plan/section3/312427-another-useful-hook.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Code: 進階掛鉤與資料流解析</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Noto+Sans+TC:wght@400;500;700;900&display=swap" rel="stylesheet">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        bgMain: '#F8F8F5',
+                        darkMain: '#1A1A1A',
+                        accentPrimary: '#C88A64',
+                        codeBg: '#242424',
+                    },
+                    fontFamily: {
+                        sans: ['"Noto Sans TC"', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'monospace'],
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        /* 隱藏捲軸，保護橫向滑動區塊 */
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+        .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+        
+        body { background-color: #F8F8F5; color: #1A1A1A; }
+        
+        /* 程式碼高亮基礎樣式 */
+        .json-key { color: #C88A64; }
+        .json-string { color: #A3BE8C; }
+        .json-number { color: #D08770; }
+        .json-boolean { color: #B48EAD; }
+
+        .fade-in { animation: fadeIn 0.4s ease-in-out forwards; }
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(10px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        .flow-path {
+            stroke-dasharray: 10;
+            animation: dash 20s linear infinite;
+        }
+        @keyframes dash { to { stroke-dashoffset: -1000; } }
+    </style>
+</head>
+<body class="font-sans antialiased min-h-screen py-10 px-4 md:px-12 selection:bg-accentPrimary selection:text-white">
+
+    <!-- Header -->
+    <header class="max-w-6xl mx-auto mb-16 fade-in">
+        <div class="flex items-center gap-4 mb-4">
+            <div class="bg-darkMain text-bgMain p-3 rounded-xl">
+                <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+            </div>
+            <div>
+                <p class="text-accentPrimary font-bold tracking-widest text-sm uppercase">Claude Code In Action</p>
+                <h1 class="text-4xl md:text-5xl font-black text-darkMain">進階 Hooks 與多型態資料流</h1>
+            </div>
+        </div>
+        <p class="text-lg md:text-xl font-medium max-w-3xl leading-relaxed text-gray-700">
+            超越 `PreToolUse` 與 `PostToolUse`，掌握 Claude Agent 的全生命週期。本指南將剖析多型態 `stdin` 的資料結構陷阱，並實作攔截除錯模式。
+        </p>
+    </header>
+
+    <!-- Module 1: Lifecycle Radar -->
+    <section class="max-w-6xl mx-auto mb-20 fade-in" style="animation-delay: 0.1s;">
+        <div class="flex items-center justify-between mb-6">
+            <h2 class="text-2xl font-bold text-darkMain flex items-center gap-3">
+                <svg class="w-6 h-6 text-accentPrimary" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"></path></svg>
+                模組一：Agent 生命週期事件探測
+            </h2>
+        </div>
+        
+        <div class="bg-white rounded-2xl shadow-sm border border-gray-200 overflow-hidden relative">
+            <div class="w-full overflow-x-auto no-scrollbar p-8 bg-darkMain relative">
+                <div class="min-w-[800px] flex justify-between items-center relative py-12">
+                    <!-- Base connecting line -->
+                    <div class="absolute left-10 right-10 top-1/2 h-1 bg-gray-700 -translate-y-1/2 z-0"></div>
+                    
+                    <!-- Nodes -->
+                    <div id="nodes-container" class="w-full flex justify-between relative z-10 px-4">
+                        <!-- JS injected nodes here -->
+                    </div>
+                </div>
+            </div>
+            
+            <div id="lifecycle-details" class="p-8 bg-white min-h-[160px] border-t-4 border-accentPrimary transition-all duration-300">
+                <h3 class="text-2xl font-bold text-darkMain mb-2">請點擊上方事件節點</h3>
+                <p class="text-gray-600 text-lg">了解各個 Hook 在 Claude Code 運作過程中的確切攔截時機與情境。</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Module 2: Polymorphic Payload Mutator -->
+    <section class="max-w-6xl mx-auto mb-20 fade-in" style="animation-delay: 0.2s;">
+        <h2 class="text-2xl font-bold text-darkMain flex items-center gap-3 mb-6">
+            <svg class="w-6 h-6 text-accentPrimary" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+            模組二：多型態 Stdin 資料流模擬器
+        </h2>
+        <div class="bg-white rounded-2xl p-6 md:p-8 shadow-sm border border-gray-200">
+            <div class="mb-6">
+                <h3 class="text-xl font-bold text-darkMain mb-2 border-l-4 border-accentPrimary pl-3">最令人困惑的痛點 (The Confusing Part)</h3>
+                <p class="text-gray-700 leading-relaxed">
+                    開發 Hook 最大的挑戰在於：輸入到命令 (`stdin`) 的結構，會根據 <span class="bg-gray-100 px-2 py-1 rounded text-darkMain font-mono font-bold text-sm">Hook 類型</span> 與 <span class="bg-gray-100 px-2 py-1 rounded text-darkMain font-mono font-bold text-sm">執行的 Tool</span> 發生劇烈變化。在未確認結構前撰寫解析邏輯，極易導致腳本崩潰。
+                </p>
+            </div>
+
+            <div class="flex flex-col lg:flex-row gap-6">
+                <!-- Selectors -->
+                <div class="w-full lg:w-1/3 space-y-3">
+                    <p class="font-bold text-gray-500 uppercase text-xs tracking-wider mb-4">Select Payload Scenario</p>
+                    
+                    <button onclick="setPayload('post-todo')" class="payload-btn w-full text-left p-4 rounded-xl border-2 border-darkMain bg-darkMain text-white font-medium flex justify-between items-center transition-all group">
+                        <div>
+                            <div class="text-xs text-gray-400 font-mono mb-1">PostToolUse</div>
+                            <div>工具：TodoWrite</div>
+                        </div>
+                        <svg class="w-5 h-5 text-accentPrimary opacity-100" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+                    </button>
+                    
+                    <button onclick="setPayload('stop')" class="payload-btn w-full text-left p-4 rounded-xl border-2 border-gray-200 hover:border-accentPrimary hover:bg-[#FDF8F5] text-darkMain font-medium flex justify-between items-center transition-all group">
+                        <div>
+                            <div class="text-xs text-gray-500 font-mono mb-1">Stop</div>
+                            <div>狀態：回應結束</div>
+                        </div>
+                        <svg class="w-5 h-5 text-gray-400 group-hover:text-accentPrimary" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+                    </button>
+
+                    <button onclick="setPayload('notification')" class="payload-btn w-full text-left p-4 rounded-xl border-2 border-gray-200 hover:border-accentPrimary hover:bg-[#FDF8F5] text-darkMain font-medium flex justify-between items-center transition-all group">
+                        <div>
+                            <div class="text-xs text-gray-500 font-mono mb-1">Notification</div>
+                            <div>情境：閒置/請求權限</div>
+                        </div>
+                        <svg class="w-5 h-5 text-gray-400 group-hover:text-accentPrimary" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+                    </button>
+                </div>
+
+                <!-- Code Terminal (Scrollable Safe Area) -->
+                <div class="w-full lg:w-2/3 w-full overflow-x-auto no-scrollbar rounded-xl bg-codeBg shadow-inner border border-gray-800">
+                    <div class="min-w-[500px]">
+                        <div class="flex items-center px-4 py-2 bg-black border-b border-gray-800">
+                            <div class="flex gap-2">
+                                <div class="w-3 h-3 rounded-full bg-red-500"></div>
+                                <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
+                                <div class="w-3 h-3 rounded-full bg-green-500"></div>
+                            </div>
+                            <div class="mx-auto text-xs text-gray-400 font-mono">stdin_payload_viewer.json</div>
+                        </div>
+                        <div class="p-4 relative">
+                            <pre id="json-viewer" class="font-mono text-sm leading-relaxed overflow-hidden transition-all duration-300"></pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Module 3: JQ Interceptor Sandbox -->
+    <section class="max-w-6xl mx-auto mb-20 fade-in" style="animation-delay: 0.3s;">
+        <h2 class="text-2xl font-bold text-darkMain flex items-center gap-3 mb-6">
+            <svg class="w-6 h-6 text-accentPrimary" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd"></path></svg>
+            模組三：萬用除錯攔截器 (The Helper Hook)
+        </h2>
+        <div class="bg-darkMain text-white rounded-2xl p-6 md:p-8 shadow-xl">
+            <p class="text-gray-300 mb-8 text-lg">
+                為了克服未知的資料結構，官方推薦了一個防禦性開發技巧：設定 <code class="bg-black text-accentPrimary px-2 py-1 rounded mx-1">"matcher": "*"</code> 並利用 <code class="bg-black text-accentPrimary px-2 py-1 rounded mx-1">jq</code> 將資料流導出。體驗下方的攔截管線：
+            </p>
+
+            <div class="w-full overflow-x-auto no-scrollbar">
+                <div class="min-w-[800px] bg-[#141414] rounded-xl p-6 flex items-center justify-between border border-gray-700">
+                    <!-- Config Block -->
+                    <div class="w-1/3 bg-codeBg border border-gray-700 rounded-lg p-4 font-mono text-sm relative">
+                        <div class="text-accentPrimary mb-2">// config.json</div>
+                        <div><span class="text-[#B48EAD]">"PostToolUse"</span>: [</div>
+                        <div class="ml-4">{</div>
+                        <div class="ml-8"><span class="text-[#B48EAD]">"matcher"</span>: <span class="text-[#A3BE8C]">"*"</span>,</div>
+                        <div class="ml-8"><span class="text-[#B48EAD]">"hooks"</span>: [{</div>
+                        <div class="ml-12"><span class="text-[#B48EAD]">"type"</span>: <span class="text-[#A3BE8C]">"command"</span>,</div>
+                        <div class="ml-12 border border-accentPrimary bg-[#2A1D16] p-1 rounded my-1"><span class="text-[#B48EAD]">"command"</span>: <span class="text-[#A3BE8C]">"jq . > post-log.json"</span></div>
+                        <div class="ml-8">}]</div>
+                        <div class="ml-4">}</div>
+                        <div>]</div>
+                    </div>
+
+                    <!-- Pipeline Animation -->
+                    <div class="w-1/4 flex flex-col items-center justify-center relative">
+                        <button id="trigger-btn" onclick="fireInterceptor()" class="bg-accentPrimary hover:bg-[#b07856] text-darkMain font-bold py-3 px-6 rounded-full transition-all active:scale-95 shadow-[0_0_15px_rgba(200,138,100,0.5)] relative z-10">
+                            觸發攔截指令
+                        </button>
+                        
+                        <svg class="absolute top-1/2 left-0 w-full h-10 -translate-y-1/2 z-0" viewBox="0 0 100 20" preserveAspectRatio="none">
+                            <line x1="0" y1="10" x2="100" y2="10" stroke="#333" stroke-width="2"/>
+                            <circle id="data-packet" cx="0" cy="10" r="3" fill="#C88A64" class="opacity-0"/>
+                        </svg>
+                    </div>
+
+                    <!-- Output File -->
+                    <div class="w-1/3 bg-codeBg border border-gray-700 rounded-lg overflow-hidden flex flex-col h-[260px]">
+                        <div class="bg-[#1A1A1A] p-2 flex items-center justify-between border-b border-gray-700">
+                            <span class="text-xs text-gray-400 font-mono flex items-center gap-2">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                                post-log.json
+                            </span>
+                            <span id="file-status" class="text-xs text-gray-500">等待寫入...</span>
+                        </div>
+                        <div id="file-content" class="p-4 font-mono text-xs text-gray-500 flex-1 overflow-y-auto no-scrollbar flex items-center justify-center">
+                            無資料
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <p class="text-sm text-gray-400 mt-4 text-center">💡 透過這層輔助 Hook，我們就能明確檢視當前環境的 JSON 結構，再回頭撰寫精確的解析邏輯，避免直接踩雷。</p>
+        </div>
+    </section>
+
+    <footer class="max-w-6xl mx-auto py-8 border-t border-gray-200 text-center text-gray-500 font-mono text-sm mt-12">
+        Claude Code Deep Dive Simulator // Designed for Senior Developers // Offline Ready
+    </footer>
+
+    <!-- Logic / JavaScript -->
+    <script>
+        // --- Syntax Highlighting Utility ---
+        function syntaxHighlight(json) {
+            if (typeof json != 'string') { json = JSON.stringify(json, undefined, 2); }
+            json = json.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            return json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, function (match) {
+                var cls = 'json-number';
+                if (/^"/.test(match)) {
+                    if (/:$/.test(match)) { cls = 'json-key'; } 
+                    else { cls = 'json-string'; }
+                } else if (/true|false/.test(match)) { cls = 'json-boolean'; } 
+                else if (/null/.test(match)) { cls = 'json-boolean'; }
+                return '<span class="' + cls + '">' + match + '</span>';
+            });
+        }
+
+        // --- Module 1: Lifecycle Radar ---
+        const lifecycleNodes = [
+            { id: 'SessionStart', label: 'SessionStart', desc: '啟動或恢復一個會話。適合初始化環境配置。' },
+            { id: 'UserPrompt', label: 'UserPromptSubmit', desc: '使用者送出提示，但 Claude 尚未開始處理前。適合做敏感詞過濾或 PII 遮蔽。' },
+            { id: 'PreTool', label: 'PreToolUse', desc: '準備呼叫 Tool 之前。可用於請求審查或前置驗證。' },
+            { id: 'PostTool', label: 'PostToolUse', desc: 'Tool 執行完成後。極度常用，可根據 tool_response 決定是否觸發後續的 CI/CD 或狀態同步。' },
+            { id: 'Notification', label: 'Notification', desc: '當 Claude 閒置超過 60 秒或需要權限使用工具時觸發。非常適合串接 Slack/Discord 警報。' },
+            { id: 'PreCompact', label: 'PreCompact', desc: '當對話過長觸發壓縮前。可在此時執行腳本，備份完整的對話脈絡 (Session Context)。' },
+            { id: 'Stop', label: 'Stop', desc: 'Claude 處理完畢，停止回應。適合觸發單元測試或資源釋放。' }
+        ];
+
+        const nodesContainer = document.getElementById('nodes-container');
+        const detailBox = document.getElementById('lifecycle-details');
+
+        function renderNodes() {
+            nodesContainer.innerHTML = '';
+            lifecycleNodes.forEach((node, index) => {
+                const el = document.createElement('div');
+                el.className = 'relative flex flex-col items-center group cursor-pointer';
+                el.onclick = () => selectNode(index);
+                
+                // Node UI
+                el.innerHTML = `
+                    <div class="node-dot w-6 h-6 rounded-full bg-gray-700 border-4 border-darkMain z-10 transition-all duration-300 group-hover:bg-accentPrimary"></div>
+                    <div class="mt-4 text-xs font-mono font-bold text-gray-400 group-hover:text-accentPrimary rotate-45 md:rotate-0 origin-left md:origin-center text-left md:text-center absolute top-8 whitespace-nowrap transition-colors">
+                        ${node.label}
+                    </div>
+                `;
+                nodesContainer.appendChild(el);
+            });
+        }
+
+        function selectNode(index) {
+            const node = lifecycleNodes[index];
+            // Reset styles
+            document.querySelectorAll('.node-dot').forEach(dot => {
+                dot.classList.remove('bg-accentPrimary', 'scale-150');
+                dot.classList.add('bg-gray-700');
+            });
+            // Set active
+            const activeDot = nodesContainer.children[index].querySelector('.node-dot');
+            activeDot.classList.remove('bg-gray-700');
+            activeDot.classList.add('bg-accentPrimary', 'scale-150');
+            
+            // Update Details
+            detailBox.innerHTML = `
+                <h3 class="text-2xl font-mono font-bold text-darkMain mb-2 flex items-center gap-2">
+                    <span class="w-3 h-3 rounded-full bg-accentPrimary inline-block"></span>
+                    ${node.label}
+                </h3>
+                <p class="text-gray-700 text-lg leading-relaxed">${node.desc}</p>
+                <div class="mt-4 inline-block bg-gray-100 px-3 py-1 rounded text-sm font-mono text-gray-500">Event Index: ${index + 1} / ${lifecycleNodes.length}</div>
+            `;
+            
+            // Add subtle flash animation
+            detailBox.classList.remove('fade-in');
+            void detailBox.offsetWidth; // trigger reflow
+            detailBox.classList.add('fade-in');
+        }
+        
+        renderNodes();
+        selectNode(3); // Default to PostToolUse
+
+        // --- Module 2: Payload Mutator ---
+        const payloads = {
+            'post-todo': {
+                "session_id": "9ecf22fa-edf8-4332-ae85-b6d5456eda64",
+                "transcript_path": "/var/log/claude/transcript.json",
+                "hook_event_name": "PostToolUse",
+                "tool_name": "TodoWrite",
+                "tool_input": {
+                    "todos": [{ "content": "write a readme", "status": "pending", "id": "1" }]
+                },
+                "tool_response": {
+                    "oldTodos": [],
+                    "newTodos": [{ "content": "write a readme", "status": "pending", "id": "1" }]
+                }
+            },
+            'stop': {
+                "session_id": "af9f50b6-f042-4773-b3e2-c3a4814765ce",
+                "transcript_path": "/var/log/claude/transcript.json",
+                "hook_event_name": "Stop",
+                "stop_hook_active": false
+            },
+            'notification': {
+                "session_id": "c1f8a8b1-1234-4567-89ab-cdef12345678",
+                "hook_event_name": "Notification",
+                "notification_type": "IdleTimeout",
+                "message": "Claude Code has been idle for 60 seconds.",
+                "requires_permission": false
+            }
+        };
+
+        function setPayload(type) {
+            // Update buttons visually
+            document.querySelectorAll('.payload-btn').forEach(btn => {
+                btn.classList.remove('bg-darkMain', 'text-white', 'border-darkMain');
+                btn.classList.add('bg-transparent', 'text-darkMain', 'border-gray-200');
+                btn.querySelector('svg').classList.remove('text-accentPrimary');
+                btn.querySelector('svg').classList.add('text-gray-400');
+                const title = btn.querySelector('.text-xs');
+                title.classList.remove('text-gray-400');
+                title.classList.add('text-gray-500');
+            });
+            
+            const activeBtn = document.querySelector(`.payload-btn[onclick="setPayload('${type}')"]`);
+            activeBtn.classList.add('bg-darkMain', 'text-white', 'border-darkMain');
+            activeBtn.classList.remove('bg-transparent', 'text-darkMain', 'border-gray-200', 'hover:border-accentPrimary', 'hover:bg-[#FDF8F5]');
+            activeBtn.querySelector('svg').classList.add('text-accentPrimary');
+            activeBtn.querySelector('svg').classList.remove('text-gray-400');
+            const title = activeBtn.querySelector('.text-xs');
+            title.classList.add('text-gray-400');
+            title.classList.remove('text-gray-500');
+
+            // Render JSON
+            const viewer = document.getElementById('json-viewer');
+            viewer.innerHTML = syntaxHighlight(payloads[type]);
+            
+            // Animation
+            viewer.classList.remove('fade-in');
+            void viewer.offsetWidth;
+            viewer.classList.add('fade-in');
+        }
+
+        // Init Module 2
+        setPayload('post-todo');
+
+        // --- Module 3: Interceptor Pipeline ---
+        function fireInterceptor() {
+            const btn = document.getElementById('trigger-btn');
+            const packet = document.getElementById('data-packet');
+            const status = document.getElementById('file-status');
+            const content = document.getElementById('file-content');
+            
+            if(btn.disabled) return;
+            
+            // Reset
+            btn.disabled = true;
+            btn.innerText = '攔截處理中...';
+            content.innerHTML = '';
+            status.innerText = '寫入中...';
+            status.classList.add('text-accentPrimary');
+            
+            // Animate Packet
+            packet.classList.remove('opacity-0');
+            packet.animate([
+                { cx: '0', opacity: 1 },
+                { cx: '50', opacity: 1, offset: 0.8 },
+                { cx: '100', opacity: 0 }
+            ], {
+                duration: 1000,
+                easing: 'ease-in-out'
+            }).onfinish = () => {
+                packet.classList.add('opacity-0');
+                
+                // Show Result
+                const dummyData = {
+                    "timestamp": new Date().toISOString(),
+                    "hook_event_name": "PostToolUse",
+                    "intercepted": true,
+                    "raw_stdin": payloads['post-todo']
+                };
+                
+                content.classList.remove('flex', 'items-center', 'justify-center', 'text-gray-500');
+                content.classList.add('text-left');
+                content.innerHTML = `<pre class="text-[10px] sm:text-xs">` + syntaxHighlight(dummyData) + `</pre>`;
+                
+                status.innerText = '寫入完成！';
+                status.classList.remove('text-accentPrimary');
+                status.classList.add('text-green-500');
+                
+                btn.innerText = '再次觸發攔截';
+                btn.disabled = false;
+            };
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## 變更摘要

新增 Section 3 — Hooks & SDK 的 7 個互動式 HTML 教學筆記，並完善 overview 頁面。

## 變更內容

### 新增互動式 HTML 頁面
- 7 個 lesson 以互動式 HTML 頁面呈現，放置於 `public/2026-plan/section3/`
- 312000 Introducing hooks
- 312001 The Claude Code SDK
- 312002 Defining hooks
- 312003 Implementing a hook
- 312004 Useful hooks
- 312423 Gotchas around hooks
- 312427 Another useful hook

### 完善 overview 頁面
- 重寫 `1.overview.md`，新增各 Lesson 速覽與建議閱讀順序
- 表格主題欄直接連結至對應 HTML 頁面（`target="_blank"` 開新分頁）

### Bug 修復
- `nuxt.config.ts`：加入 `content.ignores` 排除 AGENTS.md / CLAUDE.md 被 Nuxt Content 當成頁面渲染
- `AppSubtitle.vue`：加入 null guard，修復訪問無內容路由時的 500 錯誤